### PR TITLE
Fixes for issues #80 and #81.

### DIFF
--- a/website/js/NavBarNew.js
+++ b/website/js/NavBarNew.js
@@ -59,6 +59,8 @@ var NavBarNew = React.createClass({
                     <Nav eventKey={0} navbar right>
                         <NavLink to='/'>Home</NavLink>
                         <NavLink to='/variants'>Variants</NavLink>
+                        <NavLink to='/community'>Community</NavLink>
+                        <NavLink to='/help'>Help</NavLink>
                         <DropdownButton className={this.activePath(path, "about")} ref='about' title='More'>
                             <NavLink onClick={this.close} to='/about/variation'>
                                 BRCA1, BRCA2, and Cancer
@@ -70,8 +72,6 @@ var NavBarNew = React.createClass({
                                 This Site
                             </NavLink>
                         </DropdownButton>
-                        <NavLink to='/community'>Community</NavLink>
-                        <NavLink to='/help'>Help</NavLink>
                     </Nav>
                 </Navbar>
             </div>

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -116,7 +116,7 @@ var Home = React.createClass({
         return (
             <Grid id="main-grid" className='home'>
                 <Row>
-                    <Col smOffset={3} sm={6}>
+                    <Col smOffset={2} sm={8}>
                         <VariantSearch
                             id='home-search'
                             suggestions={suggestions}


### PR DESCRIPTION
Addresses issues #80 and #81.

The fix for #80 simply moves the "More" menu item to the end of the menu.

#81 is partially fixed. The width of the search box used to be 6 columns for bootstrap's "sm" width (<992px and >768px), but is now 8, giving plenty of room to display the placeholder text. Issues remain with the placeholder being truncated on the "variants" page, and the placeholder text being generally truncated when there isn't sufficient horizontal width on the device to display the text even when the search box is full-width.