### PR TITLE
Integrate new enigma

### DIFF
--- a/pipeline/data_merging/variant-merging.py
+++ b/pipeline/data_merging/variant-merging.py
@@ -91,7 +91,8 @@ FIELD_DICT = {"1000_Genomes": GENOME1K_FIELDS,
               "BIC": BIC_FIELDS}
 
 # Enigma filename is different depending on which version of output data is used.
-ENIGMA_FILE = "enigma_variants_GRCh38_2-27-2016.tsv"
+ENIGMA_FILE = "ENIGMA_combined.tsv"
+# ENIGMA_FILE = "enigma_variants_GRCh38_2-27-2016.tsv"
 # ENIGMA_FILE = "ENIGMA_last_updated.tsv"
 
 GENOME1K_FILE = "1000G_brca.sorted.hg38.vcf"

--- a/pipeline/luigi/README.md
+++ b/pipeline/luigi/README.md
@@ -14,6 +14,6 @@ Username and password are required to download files from BIC. They can be found
 
 Username and password are also required to download files from Enigma. They can be created at [synapse.org](http://synapse.org). You will also need access to the Enigma directory with Synapse ID `syn7188267`.
 
-To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --local-scheduler`
+To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --synapse-enigma-file-id {id for combined enigma tsv from synapse} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --local-scheduler`
 
 You can replace `RunAll` with individual tasks, or comment out required tasks in the `RunAll` task to control which tasks are run. A task will not rerun if the expected output file designated by the return statement in it's `output` method already exists.


### PR DESCRIPTION
1. Takes input of enigma file id from call to luigi script.
2. Downloads enigma file, renames it, and places it in the output directory. Removed code that used to run processing in the luigi process since it is now processed before downloading.
3. Change reference to new file name in variant merge process.