### PR TITLE
Add GA4GH API documentation (WIP)

### DIFF
--- a/website/content/api.md
+++ b/website/content/api.md
@@ -1,0 +1,16 @@
+# BRCA Exchange GA4GH API
+
+<div style="display:inline-block;text-align:center">
+    <a href="http://genomicsandhealth.org"><img src="ga4gh-logo-more.png" style="width:240px;"></a>
+    <a href="https://genomics.soe.ucsc.edu"><img src="ucsc_logo.png" style="width:260px;"></a>
+</div>
+
+---
+
+The GA4GH has defined a standard interface for exchanging genomic data over HTTP called an API, or Application Programming Interface.
+
+Using the <a href="http://github.com/ga4gh/schemas">GA4GH schemas</a>, students at UCSC have developed an implementation of this interface that provides programmatic access to the BRCA Exchange variation data and annotations. 
+
+This allows the well curated and expert reviewed variation data in the BRCA exchange to be made available to application developers in most common languages.
+
+The BRCA exchange exposes the interfaces necessary for accessing variant data, which are a subset of the interfaces the GA4GH defines. For a detailed description of the interface view the generated <a href="/backend/static/brca_exchange_ga4gh_api.html"><b>documentation</b></a>.

--- a/website/content/thisSite.md
+++ b/website/content/thisSite.md
@@ -4,6 +4,8 @@ This site provides information on catalogued BRCA1 and BRCA2 genetic variants.  
 
 The <a href="http://brcaexchange.org">BRCA Exchange</a> website is a product of the <a href="https://genomicsandhealth.org/work-products-demonstration-projects/brca-challenge-0">BRCA Challenge</a> of the <a href="https://genomicsandhealth.org/">Global Alliance for Genomics and Health</a>. The web site and underlying database were developed by Molly Zhang, Charles Markello, Mary Goldman, Brian Craft, Jing Zhu, David Haussler, Melissa Cline and Benedict Paten at the Computational Genomics Lab at the UC Santa Cruz Genomics Institute and <a href="http://ratschlab.org/~raetsch">Gunnar R&auml;tsch</a> at <a href="http://www.mskcc.org">Memorial Sloan Kettering Cancer Center</a>, and Rachel Liao of the  <a href="https://genomicsandhealth.org/">Global Alliance for Genomics and Health</a>  with input and feedback from many members of the <a href="https://genomicsandhealth.org/work-products-demonstration-projects/brca-challenge-0">BRCA Challenge</a> working groups.
 
+Variant data on this site are made available using the standards based <a href="https://genomicsandhealth.org/work-products-demonstration-projects/genomics-api">GA4GH Genomics API</a>. For more information, and example usage please visit our <a href="/about/api">API description</a>.
+
 <div style="display:inline-block;text-align:center">
     <a href="http://genomicsandhealth.org"><img src="ga4gh-logo-more.png" style="width:240px;"></a>
     <a href="https://genomics.soe.ucsc.edu"><img src="ucsc_logo.png" style="width:260px;"></a>

--- a/website/django/brca/settings.py
+++ b/website/django/brca/settings.py
@@ -113,6 +113,10 @@ MEDIA_URL = "/site_media/media/"
 # Example: "/home/media/media.lawrence.com/static/"
 STATIC_ROOT = os.path.join(PROJECT_ROOT, "static")
 
+STATICFILES_DIRS = ( 
+    os.path.join(PROJECT_ROOT, 'data/static'),
+)
+
 # URL prefix for static files.
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = "/static/"

--- a/website/django/data/static/brca_exchange_ga4gh.swagger.json
+++ b/website/django/data/static/brca_exchange_ga4gh.swagger.json
@@ -1,0 +1,809 @@
+{
+  "swagger": "2.0",
+  "info": {
+    "title": "GA4GH BRCA Exchange",
+    "version": "0.1",
+    "description": "meow"
+  },
+  "host": "brcaexchange.org",
+  "basePath": "backend/data/ga4gh"
+  "schemes": [
+    "http",
+    "https"
+  ],
+  "consumes": [
+    "application/json"
+  ],
+  "produces": [
+    "application/json"
+  ],
+  "paths": {
+    "/callsets/search": {
+      "post": {
+        "summary": "Gets a list of call sets matching the search criteria.",
+        "description": "`POST /callsets/search` must accept a JSON version of\n`SearchCallSetsRequest` as the post body and will return a JSON version of\n`SearchCallSetsResponse`.",
+        "operationId": "SearchCallSets",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchCallSetsResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchCallSetsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    },
+    "/callsets/{call_set_id}": {
+      "get": {
+        "summary": "Gets a `CallSet` by ID.",
+        "description": "`GET /callsets/{id}` will return a JSON version of `CallSet`.",
+        "operationId": "GetCallSet",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghCallSet"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "call_set_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "string"
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    },
+    "/datasets/search": {
+      "post": {
+        "summary": "Gets a list of `Dataset` matching the search criteria.",
+        "description": "`POST /datasets/search` must accept a JSON version of\n`SearchDatasetsRequest` as the post body and will return a JSON\nversion of `SearchDatasetsResponse`.",
+        "operationId": "SearchDatasets",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchDatasetsResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchDatasetsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "MetadataService"
+        ]
+      }
+    },
+    "/datasets/{dataset_id}": {
+      "get": {
+        "summary": "Gets a `Dataset` by ID.",
+        "description": "`GET /datasets/{dataset_id}` will return a JSON version of\n`Dataset`.",
+        "operationId": "GetDataset",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghDataset"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "dataset_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "string"
+          }
+        ],
+        "tags": [
+          "MetadataService"
+        ]
+      }
+    },
+    "/variants/search": {
+      "post": {
+        "summary": "Gets a list of `Variant` matching the search criteria.",
+        "description": "`POST /variants/search` must accept a JSON version of\n`SearchVariantsRequest` as the post body and will return a JSON version of\n`SearchVariantsResponse`.",
+        "operationId": "SearchVariants",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchVariantsResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchVariantsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    },
+    "/variants/{variant_id}": {
+      "post": {
+        "summary": "Gets a `Variant` by ID.",
+        "description": "`GET /variants/{id}` will return a JSON version of `Variant`.",
+        "operationId": "GetVariant",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghVariant"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "variant_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "string"
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    },
+    "/variantsets/search": {
+      "post": {
+        "summary": "Gets a list of `VariantSet` matching the search criteria.",
+        "description": "`POST /variantsets/search` must accept a JSON version of\n`SearchVariantSetsRequest` as the post body and will return a JSON version\nof `SearchVariantSetsResponse`.",
+        "operationId": "SearchVariantSets",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchVariantSetsResponse"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "body",
+            "in": "body",
+            "required": true,
+            "schema": {
+              "$ref": "#/definitions/ga4ghSearchVariantSetsRequest"
+            }
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    },
+    "/variantsets/{variant_set_id}": {
+      "get": {
+        "summary": "Gets a `VariantSet` by ID.",
+        "description": "`GET /variantsets/{variant_set_id}` will return a JSON version of\n`VariantSet`.",
+        "operationId": "GetVariantSet",
+        "responses": {
+          "200": {
+            "description": "Description",
+            "schema": {
+              "$ref": "#/definitions/ga4ghVariantSet"
+            }
+          }
+        },
+        "parameters": [
+          {
+            "name": "variant_set_id",
+            "in": "path",
+            "required": true,
+            "type": "string",
+            "format": "string"
+          }
+        ],
+        "tags": [
+          "VariantService"
+        ]
+      }
+    }
+  },
+  "definitions": {
+    "ga4ghCall": {
+      "type": "object",
+      "properties": {
+        "call_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the call set this variant call belongs to.\n\nIf this field is not present, the ordering of the call sets from a\n`SearchCallSetsRequest` over this `VariantSet` is guaranteed to match\nthe ordering of the calls on this `Variant`.\nThe number of results will also be the same."
+        },
+        "call_set_name": {
+          "type": "string",
+          "format": "string",
+          "description": "The name of the call set this variant call belongs to.\nIf this field is not present, the ordering of the call sets from a\n`SearchCallSetsRequest` over this `VariantSet` is guaranteed to match\nthe ordering of the calls on this `Variant`.\nThe number of results will also be the same."
+        },
+        "genotype": {
+          "type": "array",
+          "items": {
+            "type": "integer",
+            "format": "int32"
+          },
+          "description": "The genotype of this variant call.\n\nA 0 value represents the reference allele of the associated `Variant`. Any\nother value is a 1-based index into the alternate alleles of the associated\n`Variant`.\n\nIf a variant had a referenceBases field of \"T\", an alternateBases\nvalue of [\"A\", \"C\"], and the genotype was [2, 1], that would mean the call\nrepresented the heterozygous value \"CA\" for this variant. If the genotype\nwas instead [0, 1] the represented value would be \"TA\". Ordering of the\ngenotype values is important if the phaseset field is present."
+        },
+        "genotype_likelihood": {
+          "type": "array",
+          "items": {
+            "type": "number",
+            "format": "double"
+          },
+          "description": "The genotype likelihoods for this variant call. Each array entry\nrepresents how likely a specific genotype is for this call as\nlog10(P(data | genotype)), analogous to the GL tag in the VCF spec. The\nvalue ordering is defined by the GL tag in the VCF spec."
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufListValue"
+          },
+          "description": "A map of additional variant call information."
+        },
+        "phaseset": {
+          "type": "string",
+          "format": "string",
+          "description": "If this field is populated, this variant call's genotype ordering implies\nthe phase of the bases and is consistent with any other variant calls on\nthe same contig which have the same phaseset string."
+        }
+      },
+      "description": "A `Call` represents the determination of genotype with respect to a\nparticular `Variant`.\n\nIt may include associated information such as quality\nand phasing. For example, a call might assign a probability of 0.32 to\nthe occurrence of a SNP named rs1234 in a call set with the name NA12345."
+    },
+    "ga4ghCallSet": {
+      "type": "object",
+      "properties": {
+        "bio_sample_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The BioSample the call set data was generated from."
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "description": "The date this call set was created in milliseconds from the epoch."
+        },
+        "id": {
+          "type": "string",
+          "format": "string",
+          "description": "The call set ID."
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufListValue"
+          },
+          "description": "A map of additional call set information."
+        },
+        "name": {
+          "type": "string",
+          "format": "string",
+          "description": "The call set name."
+        },
+        "updated": {
+          "type": "string",
+          "format": "int64",
+          "description": "The time at which this call set was last updated in\nmilliseconds from the epoch."
+        },
+        "variant_set_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          },
+          "description": "The IDs of the variant sets this call set has calls in."
+        }
+      },
+      "description": "A CallSet is a collection of calls that were generated by the same analysis\nof the same sample."
+    },
+    "ga4ghDataset": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "format": "string",
+          "description": "Additional, human-readable information on the dataset."
+        },
+        "id": {
+          "type": "string",
+          "format": "string",
+          "description": "The dataset's id, locally unique to the server instance."
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufListValue"
+          },
+          "description": "A map of additional dataset information."
+        },
+        "name": {
+          "type": "string",
+          "format": "string",
+          "description": "The name of the dataset."
+        }
+      },
+      "description": "A Dataset is a collection of related data of multiple types.\nData providers decide how to group data into datasets.\nSee [Metadata API](../api/metadata.html) for a more detailed discussion."
+    },
+    "ga4ghGetCallSetRequest": {
+      "type": "object",
+      "properties": {
+        "call_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the `CallSet` to be retrieved."
+        }
+      },
+      "description": "This request maps to the URL `GET /callsets/{call_set_id}`."
+    },
+    "ga4ghGetDatasetRequest": {
+      "type": "object",
+      "properties": {
+        "dataset_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the `Dataset` to be retrieved."
+        }
+      },
+      "description": "This request maps to the URL `GET /datasets/{dataset_id}`."
+    },
+    "ga4ghGetVariantRequest": {
+      "type": "object",
+      "properties": {
+        "variant_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the `Variant` to be retrieved."
+        }
+      },
+      "description": "This request maps to the URL `GET /variants/{id}`."
+    },
+    "ga4ghGetVariantSetRequest": {
+      "type": "object",
+      "properties": {
+        "variant_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the `VariantSet` to be retrieved."
+        }
+      },
+      "description": "This request maps to the URL `GET /variantsets/{id}`."
+    },
+    "ga4ghSearchCallSetsRequest": {
+      "type": "object",
+      "properties": {
+        "bio_sample_id": {
+          "type": "string",
+          "format": "string",
+          "description": "Return only call sets generated from the provided BioSample ID."
+        },
+        "name": {
+          "type": "string",
+          "format": "string",
+          "description": "Only return call sets with this name (case-sensitive, exact match)."
+        },
+        "page_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used."
+        },
+        "page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response."
+        },
+        "variant_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The VariantSet to search."
+        }
+      },
+      "description": "******************  /callsets  *********************\nThis request maps to the body of `POST /callsets/search` as JSON."
+    },
+    "ga4ghSearchCallSetsResponse": {
+      "type": "object",
+      "properties": {
+        "call_sets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghCallSet"
+          },
+          "description": "The list of matching call sets."
+        },
+        "next_page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren't any additional results."
+        }
+      },
+      "description": "This is the response from `POST /callsets/search` expressed as JSON."
+    },
+    "ga4ghSearchDatasetsRequest": {
+      "type": "object",
+      "properties": {
+        "page_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used."
+        },
+        "page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response."
+        }
+      },
+      "description": "This request maps to the body of `POST /datasets/search` as JSON."
+    },
+    "ga4ghSearchDatasetsResponse": {
+      "type": "object",
+      "properties": {
+        "datasets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghDataset"
+          },
+          "description": "The list of datasets."
+        },
+        "next_page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren't any additional results."
+        }
+      },
+      "description": "This is the response from `POST /datasets/search` expressed as JSON."
+    },
+    "ga4ghSearchVariantSetsRequest": {
+      "type": "object",
+      "properties": {
+        "dataset_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The `Dataset` to search."
+        },
+        "page_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used."
+        },
+        "page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets. To\nget the next page of results, set this parameter to the value of\n`next_page_token` from the previous response."
+        }
+      },
+      "description": "******************  /variantsets  *********************\nThis request maps to the body of `POST /variantsets/search` as JSON."
+    },
+    "ga4ghSearchVariantSetsResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren't any additional results."
+        },
+        "variant_sets": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghVariantSet"
+          },
+          "description": "The list of matching variant sets."
+        }
+      },
+      "description": "This is the response from `POST /variantsets/search` expressed as JSON."
+    },
+    "ga4ghSearchVariantsRequest": {
+      "type": "object",
+      "properties": {
+        "call_set_ids": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          },
+          "description": "Only return variant calls which belong to call sets with these IDs.\nIf unspecified, return all variants and no variant call objects."
+        },
+        "end": {
+          "type": "string",
+          "format": "int64",
+          "description": "Required. The end of the window (0-based, exclusive) for which overlapping\nvariants should be returned."
+        },
+        "page_size": {
+          "type": "integer",
+          "format": "int32",
+          "description": "Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used."
+        },
+        "page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response."
+        },
+        "reference_name": {
+          "type": "string",
+          "format": "string",
+          "description": "Required. Only return variants on this reference."
+        },
+        "start": {
+          "type": "string",
+          "format": "int64",
+          "description": "Required. The beginning of the window (0-based, inclusive) for\nwhich overlapping variants should be returned.\nGenomic positions are non-negative integers less than reference length.\nRequests spanning the join of circular genomes are represented as\ntwo requests one on each side of the join (position 0)."
+        },
+        "variant_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The `VariantSet` to search."
+        }
+      },
+      "description": "******************  /variants  *********************\nThis request maps to the body of `POST /variants/search` as JSON."
+    },
+    "ga4ghSearchVariantsResponse": {
+      "type": "object",
+      "properties": {
+        "next_page_token": {
+          "type": "string",
+          "format": "string",
+          "description": "The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren't any additional results."
+        },
+        "variants": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghVariant"
+          },
+          "description": "The list of matching variants.\nIf the `callSetId` field on the returned calls is not present,\nthe ordering of the call sets from a `SearchCallSetsRequest`\nover the parent `VariantSet` is guaranteed to match the ordering\nof the calls on each `Variant`. The number of results will also be\nthe same."
+        }
+      },
+      "description": "This is the response from `POST /variants/search` expressed as JSON."
+    },
+    "ga4ghVariant": {
+      "type": "object",
+      "properties": {
+        "alternate_bases": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          },
+          "description": "The bases that appear instead of the reference bases. Multiple alternate\nalleles are possible."
+        },
+        "calls": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghCall"
+          },
+          "description": "The variant calls for this particular variant. Each one represents the\ndetermination of genotype with respect to this variant. `Call`s in this\narray are implicitly associated with this `Variant`."
+        },
+        "created": {
+          "type": "string",
+          "format": "int64",
+          "description": "The date this variant was created in milliseconds from the epoch."
+        },
+        "end": {
+          "type": "string",
+          "format": "int64",
+          "description": "The end position (exclusive), resulting in [start, end) closed-open\ninterval.\nThis is typically calculated by `start + referenceBases.length`."
+        },
+        "id": {
+          "type": "string",
+          "format": "string",
+          "description": "The variant ID."
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufListValue"
+          },
+          "description": "A map of additional variant information."
+        },
+        "names": {
+          "type": "array",
+          "items": {
+            "type": "string",
+            "format": "string"
+          },
+          "description": "Names for the variant, for example a RefSNP ID."
+        },
+        "reference_bases": {
+          "type": "string",
+          "format": "string",
+          "description": "The reference bases for this variant. They start at the given start\nposition."
+        },
+        "reference_name": {
+          "type": "string",
+          "format": "string",
+          "title": "The reference on which this variant occurs.\n(e.g. `chr20` or `X`)"
+        },
+        "start": {
+          "type": "string",
+          "format": "int64",
+          "description": "The start position at which this variant occurs (0-based).\nThis corresponds to the first base of the string of reference bases.\nGenomic positions are non-negative integers less than reference length.\nVariants spanning the join of circular genomes are represented as\ntwo variants one on each side of the join (position 0)."
+        },
+        "updated": {
+          "type": "string",
+          "format": "int64",
+          "description": "The time at which this variant was last updated in\nmilliseconds from the epoch."
+        },
+        "variant_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the `VariantSet` this variant belongs to. This transitively\ndefines\nthe `ReferenceSet` against which the `Variant` is to be interpreted."
+        }
+      },
+      "description": "A `Variant` represents a change in DNA sequence relative to some reference.\nFor example, a variant could represent a SNP or an insertion.\nVariants belong to a `VariantSet`.\nThis is equivalent to a row in VCF."
+    },
+    "ga4ghVariantSet": {
+      "type": "object",
+      "properties": {
+        "dataset_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the dataset this variant set belongs to."
+        },
+        "id": {
+          "type": "string",
+          "format": "string",
+          "description": "The variant set ID."
+        },
+        "metadata": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/ga4ghVariantSetMetadata"
+          },
+          "description": "Optional metadata associated with this variant set.\nThis array can be used to store information about the variant set, such as\ninformation found in VCF header fields, that isn't already available in\nfirst class fields such as \"name\"."
+        },
+        "name": {
+          "type": "string",
+          "format": "string",
+          "description": "The variant set name."
+        },
+        "reference_set_id": {
+          "type": "string",
+          "format": "string",
+          "description": "The ID of the reference set that describes the sequences used by the\nvariants in this set."
+        }
+      },
+      "description": "A VariantSet is a collection of variants and variant calls intended to be\nanalyzed together."
+    },
+    "ga4ghVariantSetMetadata": {
+      "type": "object",
+      "properties": {
+        "description": {
+          "type": "string",
+          "format": "string",
+          "description": "A textual description of this metadata."
+        },
+        "id": {
+          "type": "string",
+          "format": "string",
+          "title": "User-provided ID field, not enforced by this API.\nTwo or more pieces of structured metadata with identical\nid and key fields are considered equivalent.\nFIXME: If it's not enforced, then why can't it be null?"
+        },
+        "info": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufListValue"
+          },
+          "description": "Remaining structured metadata key-value pairs."
+        },
+        "key": {
+          "type": "string",
+          "format": "string",
+          "description": "The top-level key."
+        },
+        "number": {
+          "type": "string",
+          "format": "string",
+          "description": "The number of values that can be included in a field described by this\nmetadata."
+        },
+        "type": {
+          "type": "string",
+          "format": "string",
+          "description": "The type of data."
+        },
+        "value": {
+          "type": "string",
+          "format": "string",
+          "description": "The value field for simple metadata."
+        }
+      },
+      "description": "This metadata represents VCF header information."
+    },
+    "protobufListValue": {
+      "type": "object",
+      "properties": {
+        "values": {
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/protobufValue"
+          },
+          "description": "Repeated field of dynamically typed values."
+        }
+      },
+      "description": "`ListValue` is a wrapper around a repeated field of values.\n\nThe JSON representation for `ListValue` is JSON array."
+    },
+    "protobufNullValue": {
+      "type": "string",
+      "enum": [
+        "NULL_VALUE"
+      ],
+      "default": "NULL_VALUE",
+      "description": "`NullValue` is a singleton enumeration to represent the null value for the\n`Value` type union.\n\n The JSON representation for `NullValue` is JSON `null`.\n\n - NULL_VALUE: Null value."
+    },
+    "protobufStruct": {
+      "type": "object",
+      "properties": {
+        "fields": {
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/protobufValue"
+          },
+          "description": "Map of dynamically typed values."
+        }
+      },
+      "description": "`Struct` represents a structured data value, consisting of fields\nwhich map to dynamically typed values. In some languages, `Struct`\nmight be supported by a native representation. For example, in\nscripting languages like JS a struct is represented as an\nobject. The details of that representation are described together\nwith the proto support for the language.\n\nThe JSON representation for `Struct` is JSON object."
+    },
+    "protobufValue": {
+      "type": "object",
+      "properties": {
+        "bool_value": {
+          "type": "boolean",
+          "format": "boolean",
+          "description": "Represents a boolean value."
+        },
+        "list_value": {
+          "$ref": "#/definitions/protobufListValue",
+          "description": "Represents a repeated `Value`."
+        },
+        "null_value": {
+          "$ref": "#/definitions/protobufNullValue",
+          "description": "Represents a null value."
+        },
+        "number_value": {
+          "type": "number",
+          "format": "double",
+          "description": "Represents a double value."
+        },
+        "string_value": {
+          "type": "string",
+          "format": "string",
+          "description": "Represents a string value."
+        },
+        "struct_value": {
+          "$ref": "#/definitions/protobufStruct",
+          "description": "Represents a structured value."
+        }
+      },
+      "description": "`Value` represents a dynamically typed value which can be either\nnull, a number, a string, a boolean, a recursive struct value, or a\nlist of values. A producer of value is expected to set one of that\nvariants, absence of any variant indicates an error.\n\nThe JSON representation for `Value` is JSON value."
+    }
+  }
+}

--- a/website/django/data/static/brca_exchange_ga4gh_api.html
+++ b/website/django/data/static/brca_exchange_ga4gh_api.html
@@ -1,0 +1,1231 @@
+<?xml version="1.0"?>
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"
+"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+  <head>
+    <title>GA4GH BRCA Exchange</title>
+    <style type="text/css">
+      body { 
+	font-family: Trebuchet MS, sans-serif;
+	font-size: 15px;
+	color: #444;
+	margin-right: 24px;
+}
+
+h1	{
+	font-size: 25px;
+}
+h2	{
+	font-size: 20px;
+}
+h3	{
+	font-size: 16px;
+	font-weight: bold;
+}
+hr	{
+	height: 1px;
+	border: 0;
+	color: #ddd;
+	background-color: #ddd;
+	display: none;
+}
+
+.app-desc {
+  clear: both;
+  margin-left: 20px;
+}
+.param-name {
+  width: 100%;
+}
+.license-info {
+  margin-left: 20px;
+}
+
+.license-url {
+  margin-left: 20px;
+}
+
+.model {
+  margin: 0 0 0px 20px;
+}
+
+.method {
+  margin-left: 20px;
+}
+
+.method-notes	{
+	margin: 10px 0 20px 0;
+	font-size: 90%;
+	color: #555;
+}
+
+pre {
+  padding: 10px;
+  margin-bottom: 2px;
+}
+
+.http-method {
+ text-transform: uppercase;
+}
+
+pre.get {
+  background-color: #0f6ab4;
+}
+
+pre.post {
+  background-color: #10a54a;
+}
+
+pre.put {
+  background-color: #c5862b;
+}
+
+pre.delete {
+  background-color: #a41e22;
+}
+
+.huge	{
+	color: #fff;
+}
+
+pre.example {
+  background-color: #f3f3f3;
+  padding: 10px;
+  border: 1px solid #ddd;
+}
+
+code {
+  white-space: pre;
+}
+
+.nickname {
+  font-weight: bold;
+}
+
+.method-path {
+  font-size: 1.5em;
+  background-color: #0f6ab4;
+}
+
+.up {
+  float:right;
+}
+
+.parameter {
+  width: 500px;
+}
+
+.param {
+  width: 500px;
+  padding: 10px 0 0 20px;
+  font-weight: bold;
+}
+
+.param-desc {
+  width: 700px;
+  padding: 0 0 0 20px;
+  color: #777;
+}
+
+.param-type {
+  font-style: italic;
+}
+
+.param-enum-header {
+width: 700px;
+padding: 0 0 0 60px;
+color: #777;
+font-weight: bold;
+}
+
+.param-enum {
+width: 700px;
+padding: 0 0 0 80px;
+color: #777;
+font-style: italic;
+}
+
+.field-label {
+  padding: 0;
+  margin: 0;
+  clear: both;
+}
+
+.field-items	{
+	padding: 0 0 15px 0;
+	margin-bottom: 15px;
+}
+
+.return-type {
+  clear: both;
+  padding-bottom: 10px;
+}
+
+.param-header {
+  font-weight: bold;
+}
+
+.method-tags {
+  text-align: right;
+}
+
+.method-tag {
+  background: none repeat scroll 0% 0% #24A600;
+  border-radius: 3px;
+  padding: 2px 10px;
+  margin: 2px;
+  color: #FFF;
+  display: inline-block;
+  text-decoration: none;
+}
+    </style>
+  </head>
+  <body>
+  <h1>GA4GH BRCA Exchange</h1>
+    <div class="app-desc">meow</div>
+    <div class="app-desc">More information: <a href="https://helloreverb.com">https://helloreverb.com</a></div>
+    <div class="app-desc">Contact Info: <a href="hello@helloreverb.com">hello@helloreverb.com</a></div>
+    <div class="app-desc">Version: 0.1</div>
+    <div class="license-info">All rights reserved</div>
+    <div class="license-url">http://apache.org/licenses/LICENSE-2.0.html</div>
+  <h2>Access</h2>
+  
+
+  <h2><a name="__Methods">Methods</a></h2>
+  [ Jump to <a href="#__Models">Models</a> ]
+
+  
+  <h2>Table of Contents </h2>
+  <div class="method-summary"></div>
+  
+  <ol>
+  
+  
+  
+  <li><a href="#getDataset"><code><span class="http-method">get</span> /v0.6.0a8/datasets/{dataset_id}</code></a></li>
+  
+  <li><a href="#searchDatasets"><code><span class="http-method">post</span> /v0.6.0a8/datasets/search</code></a></li>
+  
+  
+  
+  
+  
+  <li><a href="#getCallSet"><code><span class="http-method">get</span> /v0.6.0a8/callsets/{call_set_id}</code></a></li>
+  
+  <li><a href="#getVariant"><code><span class="http-method">post</span> /v0.6.0a8/variants/{variant_id}</code></a></li>
+  
+  <li><a href="#getVariantSet"><code><span class="http-method">get</span> /v0.6.0a8/variantsets/{variant_set_id}</code></a></li>
+  
+  <li><a href="#searchCallSets"><code><span class="http-method">post</span> /v0.6.0a8/callsets/search</code></a></li>
+  
+  <li><a href="#searchVariantSets"><code><span class="http-method">post</span> /v0.6.0a8/variantsets/search</code></a></li>
+  
+  <li><a href="#searchVariants"><code><span class="http-method">post</span> /v0.6.0a8/variants/search</code></a></li>
+  
+  
+  
+  </ol>
+  
+
+  
+  
+  
+  
+  <div class="method"><a name="getDataset"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /v0.6.0a8/datasets/{dataset_id}</code></pre></div>
+    <div class="method-summary">Gets a `Dataset` by ID. (<span class="nickname">getDataset</span>)</div>
+    
+    <div class="method-notes">`GET /datasets/{dataset_id}` will return a JSON version of\n`Dataset`.</div>
+
+    
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">dataset_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghDataset">ga4ghDataset</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="searchDatasets"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v0.6.0a8/datasets/search</code></pre></div>
+    <div class="method-summary">Gets a list of `Dataset` matching the search criteria. (<span class="nickname">searchDatasets</span>)</div>
+    
+    <div class="method-notes">`POST /datasets/search` must accept a JSON version of\n`SearchDatasetsRequest` as the post body and will return a JSON\nversion of `SearchDatasetsResponse`.</div>
+
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">body (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghSearchDatasetsResponse">ga4ghSearchDatasetsResponse</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  
+  
+  
+  
+  <div class="method"><a name="getCallSet"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /v0.6.0a8/callsets/{call_set_id}</code></pre></div>
+    <div class="method-summary">Gets a `CallSet` by ID. (<span class="nickname">getCallSet</span>)</div>
+    
+    <div class="method-notes">`GET /callsets/{id}` will return a JSON version of `CallSet`.</div>
+
+    
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">call_set_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghCallSet">ga4ghCallSet</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="getVariant"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v0.6.0a8/variants/{variant_id}</code></pre></div>
+    <div class="method-summary">Gets a `Variant` by ID. (<span class="nickname">getVariant</span>)</div>
+    
+    <div class="method-notes">`GET /variants/{id}` will return a JSON version of `Variant`.</div>
+
+    
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">variant_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghVariant">ga4ghVariant</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="getVariantSet"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="get"><code class="huge"><span class="http-method">get</span> /v0.6.0a8/variantsets/{variant_set_id}</code></pre></div>
+    <div class="method-summary">Gets a `VariantSet` by ID. (<span class="nickname">getVariantSet</span>)</div>
+    
+    <div class="method-notes">`GET /variantsets/{variant_set_id}` will return a JSON version of\n`VariantSet`.</div>
+
+    
+    <h3 class="field-label">Path parameters</h3>
+    <div class="field-items">
+      <div class="param">variant_set_id (required)</div>
+
+      <div class="param-desc"><span class="param-type">Path Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghVariantSet">ga4ghVariantSet</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="searchCallSets"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v0.6.0a8/callsets/search</code></pre></div>
+    <div class="method-summary">Gets a list of call sets matching the search criteria. (<span class="nickname">searchCallSets</span>)</div>
+    
+    <div class="method-notes">`POST /callsets/search` must accept a JSON version of\n`SearchCallSetsRequest` as the post body and will return a JSON version of\n`SearchCallSetsResponse`.</div>
+
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">body (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghSearchCallSetsResponse">ga4ghSearchCallSetsResponse</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="searchVariantSets"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v0.6.0a8/variantsets/search</code></pre></div>
+    <div class="method-summary">Gets a list of `VariantSet` matching the search criteria. (<span class="nickname">searchVariantSets</span>)</div>
+    
+    <div class="method-notes">`POST /variantsets/search` must accept a JSON version of\n`SearchVariantSetsRequest` as the post body and will return a JSON version\nof `SearchVariantSetsResponse`.</div>
+
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">body (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghSearchVariantSetsResponse">ga4ghSearchVariantSetsResponse</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  <div class="method"><a name="searchVariants"/>
+    <div class="method-path">
+    <a class="up" href="#__Methods">Up</a>
+    <pre class="post"><code class="huge"><span class="http-method">post</span> /v0.6.0a8/variants/search</code></pre></div>
+    <div class="method-summary">Gets a list of `Variant` matching the search criteria. (<span class="nickname">searchVariants</span>)</div>
+    
+    <div class="method-notes">`POST /variants/search` must accept a JSON version of\n`SearchVariantsRequest` as the post body and will return a JSON version of\n`SearchVariantsResponse`.</div>
+
+    
+
+    
+    <h3 class="field-label">Consumes</h3>
+    This API call consumes the following media types via the <span class="heaader">Content-Type</span> request header:
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    
+    <h3 class="field-label">Request body</h3>
+    <div class="field-items">
+      <div class="param">body (required)</div>
+
+      <div class="param-desc"><span class="param-type">Body Parameter</span> &mdash;  </div>
+    </div>  <!-- field-items -->
+    
+
+    
+
+    
+
+    
+
+    
+    <h3 class="field-label">Return type</h3>
+    <div class="return-type">
+      <a href="#ga4ghSearchVariantsResponse">ga4ghSearchVariantsResponse</a>
+      
+    </div>
+    
+
+    <!--Todo: process Response Object and its headers, schema, examples -->
+
+    
+
+    
+    <h3 class="field-label">Produces</h3>
+    This API call produces the following media types according to the <span class="header">Accept</span> request header;
+    the media type will be conveyed by the <span class="heaader">Content-Type</span> response header.
+    <ul>
+    
+      <li><code>application/json</code></li>
+    
+    </ul>
+    
+
+    <h3 class="field-label">Responses</h3>
+    
+    <h4 class="field-label">200</h4>
+    Description
+    
+    
+  </div> <!-- method -->
+  <hr/>
+  
+  
+  
+  
+
+  <div class="up"><a href="#__Models">Up</a></div>
+  <h2><a name="__Models">Models</a></h2>
+  [ Jump to <a href="#__Methods">Methods</a> ]
+
+  <h2>Table of Contents</h2>
+  <ol>
+  
+  
+    <li><a href="#Ga4ghCall"><code>Ga4ghCall</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghCallSet"><code>Ga4ghCallSet</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghDataset"><code>Ga4ghDataset</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghGetCallSetRequest"><code>Ga4ghGetCallSetRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghGetDatasetRequest"><code>Ga4ghGetDatasetRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghGetVariantRequest"><code>Ga4ghGetVariantRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghGetVariantSetRequest"><code>Ga4ghGetVariantSetRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchCallSetsRequest"><code>Ga4ghSearchCallSetsRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchCallSetsResponse"><code>Ga4ghSearchCallSetsResponse</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchDatasetsRequest"><code>Ga4ghSearchDatasetsRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchDatasetsResponse"><code>Ga4ghSearchDatasetsResponse</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchVariantSetsRequest"><code>Ga4ghSearchVariantSetsRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchVariantSetsResponse"><code>Ga4ghSearchVariantSetsResponse</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchVariantsRequest"><code>Ga4ghSearchVariantsRequest</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghSearchVariantsResponse"><code>Ga4ghSearchVariantsResponse</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghVariant"><code>Ga4ghVariant</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghVariantSet"><code>Ga4ghVariantSet</code></a></li>
+  
+  
+  
+    <li><a href="#Ga4ghVariantSetMetadata"><code>Ga4ghVariantSetMetadata</code></a></li>
+  
+  
+  
+    <li><a href="#ProtobufListValue"><code>ProtobufListValue</code></a></li>
+  
+  
+  
+    <li><a href="#ProtobufNullValue"><code>ProtobufNullValue</code></a></li>
+  
+  
+  
+    <li><a href="#ProtobufStruct"><code>ProtobufStruct</code></a></li>
+  
+  
+  
+    <li><a href="#ProtobufValue"><code>ProtobufValue</code></a></li>
+  
+  
+  </ol>
+
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghCall">Ga4ghCall</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">call_set_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the call set this variant call belongs to.\n\nIf this field is not present, the ordering of the call sets from a\n`SearchCallSetsRequest` over this `VariantSet` is guaranteed to match\nthe ordering of the calls on this `Variant`.\nThe number of results will also be the same.</div>
+      
+      <div class="param">call_set_name </div><div class="param-desc"><span class="param-type">String</span> The name of the call set this variant call belongs to.\nIf this field is not present, the ordering of the call sets from a\n`SearchCallSetsRequest` over this `VariantSet` is guaranteed to match\nthe ordering of the calls on this `Variant`.\nThe number of results will also be the same.</div>
+      
+      <div class="param">genotype </div><div class="param-desc"><span class="param-type">array[Integer]</span> The genotype of this variant call.\n\nA 0 value represents the reference allele of the associated `Variant`. Any\nother value is a 1-based index into the alternate alleles of the associated\n`Variant`.\n\nIf a variant had a referenceBases field of \&quot;T\&quot;, an alternateBases\nvalue of [\&quot;A\&quot;, \&quot;C\&quot;], and the genotype was [2, 1], that would mean the call\nrepresented the heterozygous value \&quot;CA\&quot; for this variant. If the genotype\nwas instead [0, 1] the represented value would be \&quot;TA\&quot;. Ordering of the\ngenotype values is important if the phaseset field is present.</div>
+      
+      <div class="param">genotype_likelihood </div><div class="param-desc"><span class="param-type">array[Double]</span> The genotype likelihoods for this variant call. Each array entry\nrepresents how likely a specific genotype is for this call as\nlog10(P(data | genotype)), analogous to the GL tag in the VCF spec. The\nvalue ordering is defined by the GL tag in the VCF spec.</div>
+      
+      <div class="param">info </div><div class="param-desc"><span class="param-type">map[String, protobufListValue]</span> A map of additional variant call information.</div>
+      
+      <div class="param">phaseset </div><div class="param-desc"><span class="param-type">String</span> If this field is populated, this variant call&#39;s genotype ordering implies\nthe phase of the bases and is consistent with any other variant calls on\nthe same contig which have the same phaseset string.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghCallSet">Ga4ghCallSet</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">bio_sample_id </div><div class="param-desc"><span class="param-type">String</span> The BioSample the call set data was generated from.</div>
+      
+      <div class="param">created </div><div class="param-desc"><span class="param-type">String</span> The date this call set was created in milliseconds from the epoch.</div>
+      
+      <div class="param">id </div><div class="param-desc"><span class="param-type">String</span> The call set ID.</div>
+      
+      <div class="param">info </div><div class="param-desc"><span class="param-type">map[String, protobufListValue]</span> A map of additional call set information.</div>
+      
+      <div class="param">name </div><div class="param-desc"><span class="param-type">String</span> The call set name.</div>
+      
+      <div class="param">updated </div><div class="param-desc"><span class="param-type">String</span> The time at which this call set was last updated in\nmilliseconds from the epoch.</div>
+      
+      <div class="param">variant_set_ids </div><div class="param-desc"><span class="param-type">array[String]</span> The IDs of the variant sets this call set has calls in.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghDataset">Ga4ghDataset</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">description </div><div class="param-desc"><span class="param-type">String</span> Additional, human-readable information on the dataset.</div>
+      
+      <div class="param">id </div><div class="param-desc"><span class="param-type">String</span> The dataset&#39;s id, locally unique to the server instance.</div>
+      
+      <div class="param">info </div><div class="param-desc"><span class="param-type">map[String, protobufListValue]</span> A map of additional dataset information.</div>
+      
+      <div class="param">name </div><div class="param-desc"><span class="param-type">String</span> The name of the dataset.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghGetCallSetRequest">Ga4ghGetCallSetRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">call_set_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the `CallSet` to be retrieved.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghGetDatasetRequest">Ga4ghGetDatasetRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">dataset_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the `Dataset` to be retrieved.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghGetVariantRequest">Ga4ghGetVariantRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">variant_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the `Variant` to be retrieved.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghGetVariantSetRequest">Ga4ghGetVariantSetRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">variant_set_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the `VariantSet` to be retrieved.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchCallSetsRequest">Ga4ghSearchCallSetsRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">bio_sample_id </div><div class="param-desc"><span class="param-type">String</span> Return only call sets generated from the provided BioSample ID.</div>
+      
+      <div class="param">name </div><div class="param-desc"><span class="param-type">String</span> Only return call sets with this name (case-sensitive, exact match).</div>
+      
+      <div class="param">page_size </div><div class="param-desc"><span class="param-type">Integer</span> Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used.</div>
+      
+      <div class="param">page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response.</div>
+      
+      <div class="param">variant_set_id </div><div class="param-desc"><span class="param-type">String</span> The VariantSet to search.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchCallSetsResponse">Ga4ghSearchCallSetsResponse</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">call_sets </div><div class="param-desc"><span class="param-type">array[ga4ghCallSet]</span> The list of matching call sets.</div>
+      
+      <div class="param">next_page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren&#39;t any additional results.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchDatasetsRequest">Ga4ghSearchDatasetsRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">page_size </div><div class="param-desc"><span class="param-type">Integer</span> Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used.</div>
+      
+      <div class="param">page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchDatasetsResponse">Ga4ghSearchDatasetsResponse</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">datasets </div><div class="param-desc"><span class="param-type">array[ga4ghDataset]</span> The list of datasets.</div>
+      
+      <div class="param">next_page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren&#39;t any additional results.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchVariantSetsRequest">Ga4ghSearchVariantSetsRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">dataset_id </div><div class="param-desc"><span class="param-type">String</span> The `Dataset` to search.</div>
+      
+      <div class="param">page_size </div><div class="param-desc"><span class="param-type">Integer</span> Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used.</div>
+      
+      <div class="param">page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets. To\nget the next page of results, set this parameter to the value of\n`next_page_token` from the previous response.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchVariantSetsResponse">Ga4ghSearchVariantSetsResponse</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">next_page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren&#39;t any additional results.</div>
+      
+      <div class="param">variant_sets </div><div class="param-desc"><span class="param-type">array[ga4ghVariantSet]</span> The list of matching variant sets.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchVariantsRequest">Ga4ghSearchVariantsRequest</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">call_set_ids </div><div class="param-desc"><span class="param-type">array[String]</span> Only return variant calls which belong to call sets with these IDs.\nIf unspecified, return all variants and no variant call objects.</div>
+      
+      <div class="param">end </div><div class="param-desc"><span class="param-type">String</span> Required. The end of the window (0-based, exclusive) for which overlapping\nvariants should be returned.</div>
+      
+      <div class="param">page_size </div><div class="param-desc"><span class="param-type">Integer</span> Specifies the maximum number of results to return in a single page.\nIf unspecified, a system default will be used.</div>
+      
+      <div class="param">page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nTo get the next page of results, set this parameter to the value of\n`next_page_token` from the previous response.</div>
+      
+      <div class="param">reference_name </div><div class="param-desc"><span class="param-type">String</span> Required. Only return variants on this reference.</div>
+      
+      <div class="param">start </div><div class="param-desc"><span class="param-type">String</span> Required. The beginning of the window (0-based, inclusive) for\nwhich overlapping variants should be returned.\nGenomic positions are non-negative integers less than reference length.\nRequests spanning the join of circular genomes are represented as\ntwo requests one on each side of the join (position 0).</div>
+      
+      <div class="param">variant_set_id </div><div class="param-desc"><span class="param-type">String</span> The `VariantSet` to search.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghSearchVariantsResponse">Ga4ghSearchVariantsResponse</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">next_page_token </div><div class="param-desc"><span class="param-type">String</span> The continuation token, which is used to page through large result sets.\nProvide this value in a subsequent request to return the next page of\nresults. This field will be empty if there aren&#39;t any additional results.</div>
+      
+      <div class="param">variants </div><div class="param-desc"><span class="param-type">array[ga4ghVariant]</span> The list of matching variants.\nIf the `callSetId` field on the returned calls is not present,\nthe ordering of the call sets from a `SearchCallSetsRequest`\nover the parent `VariantSet` is guaranteed to match the ordering\nof the calls on each `Variant`. The number of results will also be\nthe same.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghVariant">Ga4ghVariant</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">alternate_bases </div><div class="param-desc"><span class="param-type">array[String]</span> The bases that appear instead of the reference bases. Multiple alternate\nalleles are possible.</div>
+      
+      <div class="param">calls </div><div class="param-desc"><span class="param-type">array[ga4ghCall]</span> The variant calls for this particular variant. Each one represents the\ndetermination of genotype with respect to this variant. `Call`s in this\narray are implicitly associated with this `Variant`.</div>
+      
+      <div class="param">created </div><div class="param-desc"><span class="param-type">String</span> The date this variant was created in milliseconds from the epoch.</div>
+      
+      <div class="param">end </div><div class="param-desc"><span class="param-type">String</span> The end position (exclusive), resulting in [start, end) closed-open\ninterval.\nThis is typically calculated by `start + referenceBases.length`.</div>
+      
+      <div class="param">id </div><div class="param-desc"><span class="param-type">String</span> The variant ID.</div>
+      
+      <div class="param">info </div><div class="param-desc"><span class="param-type">map[String, protobufListValue]</span> A map of additional variant information.</div>
+      
+      <div class="param">names </div><div class="param-desc"><span class="param-type">array[String]</span> Names for the variant, for example a RefSNP ID.</div>
+      
+      <div class="param">reference_bases </div><div class="param-desc"><span class="param-type">String</span> The reference bases for this variant. They start at the given start\nposition.</div>
+      
+      <div class="param">reference_name </div><div class="param-desc"><span class="param-type">String</span> </div>
+      
+      <div class="param">start </div><div class="param-desc"><span class="param-type">String</span> The start position at which this variant occurs (0-based).\nThis corresponds to the first base of the string of reference bases.\nGenomic positions are non-negative integers less than reference length.\nVariants spanning the join of circular genomes are represented as\ntwo variants one on each side of the join (position 0).</div>
+      
+      <div class="param">updated </div><div class="param-desc"><span class="param-type">String</span> The time at which this variant was last updated in\nmilliseconds from the epoch.</div>
+      
+      <div class="param">variant_set_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the `VariantSet` this variant belongs to. This transitively\ndefines\nthe `ReferenceSet` against which the `Variant` is to be interpreted.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghVariantSet">Ga4ghVariantSet</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">dataset_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the dataset this variant set belongs to.</div>
+      
+      <div class="param">id </div><div class="param-desc"><span class="param-type">String</span> The variant set ID.</div>
+      
+      <div class="param">metadata </div><div class="param-desc"><span class="param-type">array[ga4ghVariantSetMetadata]</span> Optional metadata associated with this variant set.\nThis array can be used to store information about the variant set, such as\ninformation found in VCF header fields, that isn&#39;t already available in\nfirst class fields such as \&quot;name\&quot;.</div>
+      
+      <div class="param">name </div><div class="param-desc"><span class="param-type">String</span> The variant set name.</div>
+      
+      <div class="param">reference_set_id </div><div class="param-desc"><span class="param-type">String</span> The ID of the reference set that describes the sequences used by the\nvariants in this set.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="Ga4ghVariantSetMetadata">Ga4ghVariantSetMetadata</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">description </div><div class="param-desc"><span class="param-type">String</span> A textual description of this metadata.</div>
+      
+      <div class="param">id </div><div class="param-desc"><span class="param-type">String</span> </div>
+      
+      <div class="param">info </div><div class="param-desc"><span class="param-type">map[String, protobufListValue]</span> Remaining structured metadata key-value pairs.</div>
+      
+      <div class="param">key </div><div class="param-desc"><span class="param-type">String</span> The top-level key.</div>
+      
+      <div class="param">number </div><div class="param-desc"><span class="param-type">String</span> The number of values that can be included in a field described by this\nmetadata.</div>
+      
+      <div class="param">type </div><div class="param-desc"><span class="param-type">String</span> The type of data.</div>
+      
+      <div class="param">value </div><div class="param-desc"><span class="param-type">String</span> The value field for simple metadata.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="ProtobufListValue">ProtobufListValue</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">values </div><div class="param-desc"><span class="param-type">array[protobufValue]</span> Repeated field of dynamically typed values.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="ProtobufNullValue">ProtobufNullValue</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="ProtobufStruct">ProtobufStruct</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">fields </div><div class="param-desc"><span class="param-type">map[String, protobufValue]</span> Map of dynamically typed values.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  
+  <div class="model">
+    <h3 class="field-label"><a name="ProtobufValue">ProtobufValue</a> <a class="up" href="#__Models">Up</a></h3>
+    <div class="field-items">
+      <div class="param">bool_value </div><div class="param-desc"><span class="param-type">Boolean</span> Represents a boolean value.</div>
+      
+      <div class="param">list_value </div><div class="param-desc"><span class="param-type">protobufListValue</span> Represents a repeated `Value`.</div>
+      
+      <div class="param">null_value </div><div class="param-desc"><span class="param-type">protobufNullValue</span> Represents a null value.</div>
+      
+      <div class="param">number_value </div><div class="param-desc"><span class="param-type">Double</span> Represents a double value.</div>
+      
+      <div class="param">string_value </div><div class="param-desc"><span class="param-type">String</span> Represents a string value.</div>
+      
+      <div class="param">struct_value </div><div class="param-desc"><span class="param-type">protobufStruct</span> Represents a structured value.</div>
+      
+      
+    </div>  <!-- field-items -->
+  </div>
+  
+  
+  </body>
+</html>

--- a/website/js/content.js
+++ b/website/js/content.js
@@ -10,6 +10,7 @@ var content = {
     helpResearch: require('../content/help_research.md'),
     disclaimer: require('../content/disclaimer.md'),
     thisSite: require('../content/thisSite.md'),
+    api: require('../content/api.md'),
     variantsDefault: require('../content/variantsDefault.md'),
     variantsResearch: require('../content/variantsResearch.md'),
     researchWarning: require('../content/researchWarning.md'),

--- a/website/js/index.js
+++ b/website/js/index.js
@@ -65,6 +65,7 @@ var Footer = React.createClass({
                         <li><a href="/about/history">About</a></li>
                         <li><a href="/variants">Variants</a></li>
                         <li><a href="/help">Help</a></li>
+                        <li><a href="/about/api">API</a></li>
                     </ul>
                 </div>
                 <div className="col-sm-2 logo-footer">


### PR DESCRIPTION
This JSON file can be used to generate static or dynamic documentation using swagger-codegen. It was created by selecting the Variant and Metadata protocols of the https://github.com/ga4gh/schemas and then generating swagger docs following [these](https://ga4gh-schemas.readthedocs.io/en/latest/appendix/swagger.html) instructions.

The BRCA Exchange offering does not support (or present) calls, or callsets.