### PR TITLE
Merge equiv variants in standardize

### DIFF
--- a/pipeline/data_merging/brca_pseudonym_generator.py
+++ b/pipeline/data_merging/brca_pseudonym_generator.py
@@ -184,24 +184,26 @@ def main(args):
             except hgvs.exceptions.HGVSParseError as e:
                 template = "An exception of type {0} occured. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
+                genomicChange = '{0}:g.{1}:{2}>{3}'.format(chrom38, offset38, ref38, alt38)
                 print('hgvs.exceptions.HGVSParseError: ', e)
                 print('Original GRCh38 Genomic Coordinate: ', oldHgvsGenomic38)
-                print('GRCh38 Genomic change: ', '{0}:{1}:{2}>{3}'.format(chrom38,offset38,ref38,alt38))
+                print('GRCh38 Genomic change: ', genomicChange)
                 logging.error(message)
                 logging.error(line)
-                logging.error('Proposed GRCh38 Genomic change for error: ', '{0}:{1}:{2}>{3}'.format(chrom38,offset38,ref38,alt38))
+                logging.error('Proposed GRCh38 Genomic change for error: %s', genomicChange)
 
             # Catch parse errors thrown by ometa.runtime.ParseError.
             except ParseError as ex:
                 template = "An exception of type {0} occured. Arguments:\n{1!r}"
                 message = template.format(type(ex).__name__, ex.args)
+                genomicChange = '{0}:g.{1}:{2}>{3}'.format(chrom38, offset38, ref38, alt38)
                 print(message)
                 print('ometa.runtime.ParseError', ex)
                 print('Original GRCh38 Genomic Coordinate: ', oldHgvsGenomic38)
-                print('GRCh38 Genomic change: ', '{0}:{1}:{2}>{3}'.format(chrom38,offset38,ref38,alt38))
+                print('GRCh38 Genomic change: ', genomicChange)
                 logging.error(message)
                 logging.error(line)
-                logging.error('Proposed GRCh38 Genomic change for error: ', '{0}:{1}:{2}>{3}'.format(chrom38,offset38,ref38,alt38))
+                logging.error('Proposed GRCh38 Genomic change for error: %s', genomicChange)
 
         # Add empty data for each new column to prepare for data insertion by index
         for i in range(len(new_columns_to_append)):

--- a/pipeline/data_merging/variant-merging.py
+++ b/pipeline/data_merging/variant-merging.py
@@ -245,8 +245,8 @@ def variant_standardize(variants="pickle"):
                     # overwrite none values with default none representation
                     existing_variant[i] = existing_variant_property
 
-                # move on if they're equal
-                if equivalent_variant_property == existing_variant_property:
+                # move on if they're equal or if equivalent variant property is blank
+                if equivalent_variant_property == existing_variant_property or equivalent_variant_property == "-":
                     continue
 
                 # if the old value is blank, replace it with the new value
@@ -264,12 +264,13 @@ def variant_standardize(variants="pickle"):
                     if type(equivalent_variant_property) == list:
                         for prop in equivalent_variant_property:
                             if prop not in merged_properties:
-                                merged_properties += prop
+                                merged_properties.append(prop)
                     elif equivalent_variant_property not in merged_properties:
-                        merged_properties += equivalent_variant_property
+                        merged_properties.append(equivalent_variant_property)
 
-                # replace existing data with updates
-                existing_variant[i] = merged_properties
+                    # replace existing data with updates
+                    existing_variant[i] = merged_properties
+                    logging.debug("Merged properties: %s", merged_properties)
 
             logging.debug('Merged output: \n %s', existing_variant)
 

--- a/pipeline/data_merging/variant-merging.py
+++ b/pipeline/data_merging/variant-merging.py
@@ -13,7 +13,6 @@ import subprocess
 import tempfile
 import vcf
 import logging
-import pdb
 from StringIO import StringIO
 from copy import deepcopy
 from pprint import pprint


### PR DESCRIPTION
This PR does three things:

1. Inserts g's in genomic coordinates for appropriate comparison with old genomic coordinates (previously, all comparisons turned up different because old coordinates had a g and new ones didn't)
2. Instead of overwriting equivalent variants in variant_standardize, they are now merged. This way we are no longer losing source references and other valuable data.
3. Fixes a bug in brca_pseudonym_generator logging syntax.