### PR TITLE
Build metadata script

### DIFF
--- a/pipeline/data_merging/buildVersionMetadata.py
+++ b/pipeline/data_merging/buildVersionMetadata.py
@@ -8,10 +8,9 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument("--date", default=datetime.datetime.now(),
                         help="Version generation date")
-    parser.add_argument("--notes", default="release_notes.txt",
+    parser.add_argument("--notes", required=True,
                         help="File with release notes text")
-    parser.add_argument("--output", default="version.json",
-                        help="Output json file")
+    parser.add_argument("--output", default="version.json", help="Output json file")
 
     args = parser.parse_args()
 

--- a/pipeline/utilities/buildVersionMetadata.py
+++ b/pipeline/utilities/buildVersionMetadata.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python
+import datetime
+import json
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--date", default=datetime.datetime.now(),
+                        help="Version generation date")
+    parser.add_argument("--notes", default="release_notes.txt",
+                        help="File with release notes text")
+    parser.add_argument("--output", default="version.json",
+                        help="Output json file")
+
+    args = parser.parse_args()
+
+    version_data = {}
+    version_data['date'] = args.date
+
+    release_notes = None
+    with open(args.notes) as release_notes_file:
+        release_notes = release_notes_file.read()
+
+    version_data['notes'] = release_notes
+
+    json_data = json.dumps(version_data, default=handler)
+
+    with open(args.output, 'w') as json_output:
+        json.dump(json_data, json_output)
+
+
+def handler(obj):
+    if hasattr(obj, 'isoformat'):
+        return obj.isoformat()
+    else:
+        raise TypeError, 'Object of type %s with value of %s is not JSON serializable' % (type(obj), repr(obj))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
this is the first pass at a version metadata generation script. note that it requires release notes in the form of a txt file as an argument.

it would be simple enough to integrate this script into the automated pipeline if we want, but for testing I kept it separate for now.