### PR TITLE
Add release diff to luigi

### DIFF
--- a/pipeline/data_merging/buildVersionMetadata.py
+++ b/pipeline/data_merging/buildVersionMetadata.py
@@ -2,6 +2,7 @@
 import datetime
 import json
 import argparse
+import os
 
 
 def main():
@@ -11,6 +12,7 @@ def main():
     parser.add_argument("--notes", required=True,
                         help="File with release notes text")
     parser.add_argument("--output", default="version.json", help="Output json file")
+    parser.add_argument("--source_file_dir", help="Directory with preprocessed source files used to generate output.")
 
     args = parser.parse_args()
 
@@ -22,6 +24,10 @@ def main():
         release_notes = release_notes_file.read()
 
     version_data['notes'] = release_notes
+
+    # TODO: come up with a way to generate this and creation dates programatically.
+    source_files = ["Bic", "ClinVar", "ESP", "ExAC", "Enigma", "LOVD", "exLOVD", "1000 Genomes"]
+    version_data['sources'] = source_files
 
     json_data = json.dumps(version_data, default=handler)
 

--- a/pipeline/data_merging/buildVersionMetadata.py
+++ b/pipeline/data_merging/buildVersionMetadata.py
@@ -2,7 +2,6 @@
 import datetime
 import json
 import argparse
-import os
 
 
 def main():

--- a/pipeline/luigi/CompileVCFFiles.py
+++ b/pipeline/luigi/CompileVCFFiles.py
@@ -112,6 +112,7 @@ lovd_method_dir = os.path.abspath('../lovd')
 g1k_method_dir = os.path.abspath('../1000_Genomes')
 enigma_method_dir = os.path.abspath('../enigma')
 data_merging_method_dir = os.path.abspath('../data_merging')
+utilities_method_dir = os.path.abspath('../utilities')
 
 
 ###############################################
@@ -1280,8 +1281,8 @@ class MergeVCFsIntoTSVFile(luigi.Task):
     file_parent_dir = luigi.Parameter(default=DEFAULT_FILE_PARENT_DIR,
                                       description='directory to store all individual task related files')
 
-    previous_release = luigi.Parameter(description='previous release for diffing versions and producing \
-                                       change types for variants')
+    previous_release = luigi.Parameter(default=None, description='previous release for diffing versions \
+                                       and producing change types for variants')
 
     def output(self):
         release_dir = create_path_if_nonexistent(self.output_dir + "/release/")
@@ -1383,7 +1384,7 @@ class RunDiffAndAppendChangeTypesToOutput(luigi.Task):
     def run(self):
         release_dir = self.output_dir + "/release/"
         brca_resources_dir = self.resources_dir
-        os.chdir(data_merging_method_dir)
+        os.chdir(utilities_method_dir)
 
         args = ["python", "releaseDiff.py", "--v2", release_dir + "built.tsv", "--v1", self.previous_release,
                 "--removed", release_dir + "removed.tsv", "--added", release_dir + "added.tsv", "--added_data",
@@ -1419,8 +1420,8 @@ class RunAll(luigi.WrapperTask):
     file_parent_dir = luigi.Parameter(default=DEFAULT_FILE_PARENT_DIR,
                                       description='directory to store all individual task related files')
 
-    previous_release = luigi.Parameter(description='previous release for diffing versions and producing \
-                                       change types for variants')
+    previous_release = luigi.Parameter(default=None, description='previous release for diffing versions \
+                                       and producing change types for variants')
 
     def requires(self):
         # If a previous release is provided, run the releaseDiff.py script to generate change_types

--- a/pipeline/luigi/README.md
+++ b/pipeline/luigi/README.md
@@ -25,7 +25,8 @@ The Luigi script takes several arguments to run:
 * `--output-dir`: the directory to store output from all sources in the luigi script
 * `--resources-dir`: the directory containing BRCA Resources obtained by following instructions in the pipeline readme
 * `--file-parent-dir`: the directory to store output from individual sources in the luigi script
+* `--previous-release` (optional): the previous data release used to compare with the newest release to determine variant changes between releases. If this argument is not provided, changes to variants between release versions will not be determined or appended to the output file.
 
-To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --synapse-enigma-file-id {id for combined enigma output file from synapse} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --local-scheduler`
+To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --synapse-enigma-file-id {id for combined enigma output file from synapse} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --previous-release $PREVIOUS_RELEASE --local-scheduler`
 
 You can replace `RunAll` with individual tasks, or comment out required tasks in the `RunAll` task to control which tasks are run. A task will not rerun if the expected output file designated by the return statement in it's `output` method already exists.

--- a/pipeline/luigi/README.md
+++ b/pipeline/luigi/README.md
@@ -26,7 +26,8 @@ The Luigi script takes several arguments to run:
 * `--resources-dir`: the directory containing BRCA Resources obtained by following instructions in the pipeline readme
 * `--file-parent-dir`: the directory to store output from individual sources in the luigi script
 * `--previous-release` (optional): the previous data release used to compare with the newest release to determine variant changes between releases. If this argument is not provided, changes to variants between release versions will not be determined or appended to the output file.
+* `--release-notes` (optional, requires `--previous-release` as well): A .txt file used to generate release notes for a version metadata file (version.json) to be included in the output directory.
 
-To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --synapse-enigma-file-id {id for combined enigma output file from synapse} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --previous-release $PREVIOUS_RELEASE --local-scheduler`
+To run: `python -m luigi --module CompileVCFFiles RunAll --u {username} --p {password} --synapse-username {username from synapse.org} --synapse-password {password from synapse.org} --synapse-enigma-file-id {id for combined enigma output file from synapse} --output-dir $OUTPUT_DIR --resources-dir $BRCA_RESOURCES --file-parent-dir $PARENT_DIR --previous-release $PREVIOUS_RELEASE --release-notes $RELEASE_NOTES --local-scheduler`
 
 You can replace `RunAll` with individual tasks, or comment out required tasks in the `RunAll` task to control which tasks are run. A task will not rerun if the expected output file designated by the return statement in it's `output` method already exists.


### PR DESCRIPTION
This PR adds the release diff script to the automated pipeline. If a previous release is provided to the run command, diffs will be auto generated and appended to the output file. The script still works as it did previously if no previous release is provided.