### PR TITLE
fix link to enigma rules

### DIFF
--- a/website/js/index.js
+++ b/website/js/index.js
@@ -415,7 +415,7 @@ var VariantDetail = React.createClass({
                         rowItem = <a target="_blank" href={variant[prop]}>link to multifactorial analysis</a>;
 					}
                 } else if (prop === "Assertion_method_citation_ENIGMA") {
-                    rowItem = <a target="_blank" href={variant[prop]}>Enigma Rules version Mar 26, 2015</a>;
+                    rowItem = <a target="_blank" href="https://enigmaconsortium.org/library/general-documents/">Enigma Rules version Mar 26, 2015</a>;
 // this will be used in All Data display
 /*                } else if (prop == "Source_URL") {
                     var url_count = 0;


### PR DESCRIPTION
data currently provides links to the wrong location: either https://enigmaconsortium.org/wp-content/uploads/2016/06/ENIGMA_Rules_2015-03-26.pdf or http://enigmaconsortium.org/documents/ENIGMA_Rules_2015-03-26.pdf, both of which show no results.