### PR TITLE
Switch to public API for protobuf conversion

### DIFF
--- a/website/django/data/tests.py
+++ b/website/django/data/tests.py
@@ -306,7 +306,7 @@ class VariantTestCase(TestCase):
         """Ensures the search variants endpoint responds with expected failure modes"""
         request = variant_service.SearchVariantsRequest()
         req = self.factory.post("/data/ga4gh/variants/search",
-                                json.dumps(json_format._MessageToJsonObject(request, False)),
+                                json.dumps(json_format.MessageToDict(request, False)),
                                 content_type="application/json")
         response = views.search_variants(req)
         self.assertEqual(response.status_code, 400, "No variant set ID should 400")
@@ -315,7 +315,7 @@ class VariantTestCase(TestCase):
                              "No variant set ID in the request should provide a useful error")
         request.variant_set_id = "Something not null"
         req = self.factory.post("/data/ga4gh/variants/search",
-                                json.dumps(json_format._MessageToJsonObject(request, False)),
+                                json.dumps(json_format.MessageToDict(request, False)),
                                 content_type="application/json")
         response = views.search_variants(req)
         self.assertEquals(response.status_code, 400)
@@ -324,7 +324,7 @@ class VariantTestCase(TestCase):
                              "A useful error is thrown when the reference name is not present")
         request.reference_name = "chr17"
         req= self.factory.post("/data/ga4gh/variants/search",
-                               json.dumps(json_format._MessageToJsonObject(request, False)),
+                               json.dumps(json_format.MessageToDict(request, False)),
                                 content_type="application/json")
         response = views.search_variants(req)
         self.assertJSONEqual(response.content,
@@ -332,14 +332,14 @@ class VariantTestCase(TestCase):
                              "A useful error is thrown when no start is present")
         request.start = 14589
         req = self.factory.post("/data/ga4gh/variants/search",
-                                json.dumps(json_format._MessageToJsonObject(request, False)),
+                                json.dumps(json_format.MessageToDict(request, False)),
                                 content_type="application/json")
         response = views.search_variants(req)
         self.assertJSONEqual(response.content, views.ErrorMessages['end'],
                              "A useful error is provided when no end is present")
         request.end = 143295
         req = self.factory.post("/data/ga4gh/variants/search",
-                                json.dumps(json_format._MessageToJsonObject(request, False)),
+                                json.dumps(json_format.MessageToDict(request, False)),
                                 content_type="application/json")
         response = views.search_variants(req)
         self.assertEquals(response.status_code, 404, "A bad variant set ID should 404")
@@ -568,7 +568,7 @@ class VariantTestCase(TestCase):
 
         response = views.brca_to_ga4gh(variant, genomic_coordinate)
 
-        json_response = json_format._MessageToJsonObject(response, True)
+        json_response = json_format.MessageToDict(response, True)
         self.assertEqual(int(json_response['start']), 32923950)
         self.assertEqual(json_response['referenceBases'], "CA")
         self.assertEqual(json_response['alternateBases'][0], "C")

--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -18,6 +18,7 @@ from ga4gh.schemas.ga4gh import variant_service_pb2 as variant_service
 from ga4gh.schemas.ga4gh import variants_pb2 as variants
 from ga4gh.schemas.ga4gh import metadata_service_pb2 as metadata_service
 from ga4gh.schemas.ga4gh import metadata_pb2 as metadata
+
 import google.protobuf.json_format as json_format
 
 
@@ -273,7 +274,7 @@ def search_variants(request):
         response.next_page_token = page_token
 
     response.variants.extend(ga_variants)
-    resp = json_format._MessageToJsonObject(response, True)
+    resp = json_format.MessageToDict(response, True)
     return JsonResponse(resp)
 
 def range_filter(reference_genome, variants, reference_name, start, end):
@@ -408,7 +409,7 @@ def get_variant(request, variant_id):
                     content_type='application/json',
                     status=404)
             ga_variant = brca_to_ga4gh(variant, set_id)
-            response = json_format._MessageToJsonObject(ga_variant, True)
+            response = json_format.MessageToDict(ga_variant, True)
             return JsonResponse(response)
         else:
             return HttpResponseBadRequest(
@@ -434,7 +435,7 @@ def search_variant_sets(request):
         if dataset_id != DATASET_ID:
             """Bad Request returns empty response"""
             return JsonResponse(
-                json_format._MessageToJsonObject(
+                json_format.MessageToDict(
                     variant_service.SearchCallSetsResponse(), True))
     if not page_size or page_size == 0:
         page_size = DEFAULT_PAGE_SIZE
@@ -450,7 +451,7 @@ def search_variant_sets(request):
         response.next_page_token = page_token
     for sets in variant_sets_list:
         response.variant_sets.extend([sets])
-    return JsonResponse(json_format._MessageToJsonObject(response, True))
+    return JsonResponse(json_format.MessageToDict(response, True))
 
 def obtain_variant_set_for_set(Set):
     variant_set = variants.VariantSet()
@@ -492,7 +493,7 @@ def get_variant_set(request, variant_set_id):
         variant_set.dataset_id = DATASET_ID
         variant_set.reference_set_id = '{}-{}'.format(REFERENCE_SET_BASE, id_)
         brca_meta(variant_set.metadata, id_)
-        resp = json_format._MessageToJsonObject(variant_set, True)
+        resp = json_format.MessageToDict(variant_set, True)
         return JsonResponse(resp)
     else:
         return JsonResponse({'Invalid Set Id': variant_set_id}, status=404)
@@ -540,7 +541,7 @@ def search_datasets(request):
         response.next_page_token = ' '
         response.datasets.extend([metadata.Dataset()])
     ##############
-    return JsonResponse(json_format._MessageToJsonObject(response, False))
+    return JsonResponse(json_format.MessageToDict(response, False))
 
 @require_http_methods(['GET'])
 def get_dataset(request, dataset_id):
@@ -556,7 +557,7 @@ def get_dataset(request, dataset_id):
     dataset.name = SETNAME
     dataset.description = 'Variants observed in brca-exchange project'
     # Needs field for info, still not available from ga4gh client
-    return JsonResponse(json_format._MessageToJsonObject(dataset, False))
+    return JsonResponse(json_format.MessageToDict(dataset, False))
 
 @require_http_methods(['GET', 'POST'])
 def empty_variantset_id_catcher(request):


### PR DESCRIPTION
I believe this was the source of our problems in the end, although it's great that we've eased deployment. The version of protobuf removed a private API call and moved it public. Thanks @acthp @zfisch  !

```
AttributeError at /data/ga4gh/v0.6.0a7/datasets/search
'module' object has no attribute '_MessageToJsonObject'
Request Method:	POST
Request URL:	http://brcaexchange-dev.cloudapp.net/backend/data/ga4gh/v0.6.0a7/datasets/search
Django Version:	1.9.8
Exception Type:	AttributeError
Exception Value:	
'module' object has no attribute '_MessageToJsonObject'
Exception Location:	/var/www/backend/beta/django/data/views.py in search_datasets, line 543
Python Executable:	/usr/bin/python
Python Version:	2.7.6
Python Path:	
['/usr/lib/python2.7',
 '/usr/lib/python2.7/plat-x86_64-linux-gnu',
 '/usr/lib/python2.7/lib-tk',
 '/usr/lib/python2.7/lib-old',
 '/usr/lib/python2.7/lib-dynload',
 '/usr/local/lib/python2.7/dist-packages',
 '/usr/lib/python2.7/dist-packages',
 '/var/www/backend/beta/virtualenv/lib/python2.7/site-packages',
 '/var/www/backend/beta/django']
Server time:	Wed, 16 Nov 2016 15:58:26 -0600
```