### PR TITLE
Search fix

### DIFF
--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -186,7 +186,7 @@ def apply_search(query, search_term, quotes='', release=None):
         NP_009225.1:p.(Ala280Gly) --> HGVS_Protein
         NP_009225.1:A280G --> HGVS_Protein.split(':')[0]:Protein_Change
     '''
-    search_term = search_term.lower()
+    search_term = search_term.lower().strip()
 
     p_hgvs_protein = re.compile("^np_[0-9]{6}.[0-9]:")
     m_hgvs_protein = p_hgvs_protein.match(search_term)
@@ -200,13 +200,10 @@ def apply_search(query, search_term, quotes='', release=None):
         suffix = search_term[12:]
         # values in synonyms column are separated by commas
         comma_prefixed_suffix = ',' + suffix
-        # need to check synonym column for colon prefixes in the case of HGVS_cDNA and HGVS_Protein fields
-        colon_prefixed_suffix = ':' + suffix
         prefix_filtered_results = query.filter(HGVS_Protein__iexact=prefix)
         results = prefix_filtered_results.filter(
             Q(Protein_Change__istartswith=suffix) |
             Q(Synonyms__icontains=comma_prefixed_suffix) |
-            Q(Synonyms__icontains=colon_prefixed_suffix) |
             Q(Synonyms__istartswith=suffix)
         ) | query.filter(Q(HGVS_Protein__icontains=search_term) | Q(Synonyms__icontains=search_term))
         non_synonyms = results.filter(Protein_Change__istartswith=suffix) | query.filter(HGVS_Protein__icontains=search_term)
@@ -216,6 +213,7 @@ def apply_search(query, search_term, quotes='', release=None):
         prefix = search_term[:5]
         search_term = search_term[6:]
         comma_prefixed_search_term = ',' + search_term
+        # need to check synonym column for colon prefixes in the case of HGVS_cDNA and HGVS_Protein fields
         colon_prefixed_search_term = ':' + search_term
         results = query.filter(Gene_Symbol__iexact=prefix).filter(
             Q(HGVS_cDNA__icontains=search_term) |
@@ -242,7 +240,6 @@ def apply_search(query, search_term, quotes='', release=None):
         prefix = search_term[:11]
         search_term = search_term[12:]
         comma_prefixed_search_term = ',' + search_term
-        colon_prefixed_search_term = ':' + search_term
         results = query.filter(Reference_Sequence__iexact=prefix).filter(
             Q(HGVS_cDNA__icontains=search_term) |
             Q(Genomic_Coordinate_hg38__istartswith=search_term) |
@@ -250,7 +247,6 @@ def apply_search(query, search_term, quotes='', release=None):
             Q(Genomic_Coordinate_hg36__istartswith=search_term) |
             Q(BIC_Nomenclature__istartswith=search_term) |
             Q(Synonyms__icontains=comma_prefixed_search_term) |
-            Q(Synonyms__icontains=colon_prefixed_search_term) |
             Q(Synonyms__istartswith=search_term)
         )
         non_synonyms = results.filter(

--- a/website/django/data/views.py
+++ b/website/django/data/views.py
@@ -200,8 +200,7 @@ def apply_search(query, search_term, quotes='', release=None):
         suffix = search_term[12:]
         # values in synonyms column are separated by commas
         comma_prefixed_suffix = ',' + suffix
-        prefix_filtered_results = query.filter(HGVS_Protein__iexact=prefix)
-        results = prefix_filtered_results.filter(
+        results = query.filter(HGVS_Protein__istartswith=prefix).filter(
             Q(Protein_Change__istartswith=suffix) |
             Q(Synonyms__icontains=comma_prefixed_suffix) |
             Q(Synonyms__istartswith=suffix)
@@ -211,48 +210,48 @@ def apply_search(query, search_term, quotes='', release=None):
     # Handle gene symbol prefixed searches
     elif search_term.startswith('brca1:') or search_term.startswith('brca2:'):
         prefix = search_term[:5]
-        search_term = search_term[6:]
-        comma_prefixed_search_term = ',' + search_term
+        suffix = search_term[6:]
+        comma_prefixed_suffix = ',' + suffix
         # need to check synonym column for colon prefixes in the case of HGVS_cDNA and HGVS_Protein fields
-        colon_prefixed_search_term = ':' + search_term
+        colon_prefixed_suffix = ':' + suffix
         results = query.filter(Gene_Symbol__iexact=prefix).filter(
-            Q(HGVS_cDNA__icontains=search_term) |
-            Q(HGVS_Protein__icontains=search_term) |
-            Q(Genomic_Coordinate_hg38__istartswith=search_term) |
-            Q(Genomic_Coordinate_hg37__istartswith=search_term) |
-            Q(Genomic_Coordinate_hg36__istartswith=search_term) |
-            Q(BIC_Nomenclature__istartswith=search_term) |
-            Q(Protein_Change__istartswith=search_term) |
-            Q(Synonyms__icontains=comma_prefixed_search_term) |
-            Q(Synonyms__icontains=colon_prefixed_search_term) |
-            Q(Synonyms__istartswith=search_term)
-        )
+            Q(HGVS_cDNA__icontains=suffix) |
+            Q(HGVS_Protein__icontains=suffix) |
+            Q(Genomic_Coordinate_hg38__istartswith=suffix) |
+            Q(Genomic_Coordinate_hg37__istartswith=suffix) |
+            Q(Genomic_Coordinate_hg36__istartswith=suffix) |
+            Q(BIC_Nomenclature__istartswith=suffix) |
+            Q(Protein_Change__istartswith=suffix) |
+            Q(Synonyms__icontains=comma_prefixed_suffix) |
+            Q(Synonyms__icontains=colon_prefixed_suffix) |
+            Q(Synonyms__istartswith=suffix)
+        ) | query.filter(Synonyms__icontains=search_term)
         non_synonyms = results.filter(
-            Q(HGVS_cDNA__icontains=search_term) |
-            Q(HGVS_Protein__icontains=search_term) |
-            Q(Genomic_Coordinate_hg38__istartswith=search_term) |
-            Q(BIC_Nomenclature__istartswith=search_term) |
-            Q(Protein_Change__istartswith=search_term)
+            Q(HGVS_cDNA__icontains=suffix) |
+            Q(HGVS_Protein__icontains=suffix) |
+            Q(Genomic_Coordinate_hg38__istartswith=suffix) |
+            Q(BIC_Nomenclature__istartswith=suffix) |
+            Q(Protein_Change__istartswith=suffix)
         )
 
     # Handle Reference_Sequence prefixed searches
     elif m_reference_sequence:
         prefix = search_term[:11]
-        search_term = search_term[12:]
-        comma_prefixed_search_term = ',' + search_term
+        suffix = search_term[12:]
+        comma_prefixed_suffix = ',' + suffix
         results = query.filter(Reference_Sequence__iexact=prefix).filter(
-            Q(HGVS_cDNA__icontains=search_term) |
-            Q(Genomic_Coordinate_hg38__istartswith=search_term) |
-            Q(Genomic_Coordinate_hg37__istartswith=search_term) |
-            Q(Genomic_Coordinate_hg36__istartswith=search_term) |
-            Q(BIC_Nomenclature__istartswith=search_term) |
-            Q(Synonyms__icontains=comma_prefixed_search_term) |
-            Q(Synonyms__istartswith=search_term)
-        )
+            Q(HGVS_cDNA__icontains=suffix) |
+            Q(Genomic_Coordinate_hg38__istartswith=suffix) |
+            Q(Genomic_Coordinate_hg37__istartswith=suffix) |
+            Q(Genomic_Coordinate_hg36__istartswith=suffix) |
+            Q(BIC_Nomenclature__istartswith=suffix) |
+            Q(Synonyms__icontains=comma_prefixed_suffix) |
+            Q(Synonyms__istartswith=suffix)
+        ) | query.filter(Synonyms__icontains=search_term)
         non_synonyms = results.filter(
-            Q(HGVS_cDNA__icontains=search_term) |
-            Q(Genomic_Coordinate_hg38__istartswith=search_term) |
-            Q(BIC_Nomenclature__istartswith=search_term)
+            Q(HGVS_cDNA__icontains=suffix) |
+            Q(Genomic_Coordinate_hg38__istartswith=suffix) |
+            Q(BIC_Nomenclature__istartswith=suffix)
         )
 
     # Generic searches (no prefixes)

--- a/website/js/hgvs.js
+++ b/website/js/hgvs.js
@@ -19,12 +19,9 @@
 
 var _ = require('underscore');
 
-var gene = 'Gene_Symbol';
 var pathogenicity = 'Clinical_significance_ENIGMA';
 
 var hgvsPatterns = [
-    {regex: /^(NM_007294\.3(\(BRCA1\))?|BRCA1)(:|$)/i, value: 'BRCA1', column: gene},
-    {regex: /^(NM_000059\.3(\(BRCA2\))?|BRCA2)(:|$)/i, value: 'BRCA2', column: gene},
     {regex: /^[Pp]athogenic(:|$)/i, value: 'Pathogenic', column: pathogenicity},
     {regex: /^[Bb]enign(:|$)/i, value: 'Benign', column: pathogenicity},
     {regex: /^([Vv]ariants of unknown significance|VUS)(:|$)/i, value: 'VUS', column: pathogenicity}


### PR DESCRIPTION
This PR addresses some common search bugs. It also moves most of the search term parsing logic to the backend to centralize it.

The most significant change is the use of filters rather than Full Text Search. Special cases are included to handle search formatting that does not match our db schema.