### PR TITLE
run eslint as part of webpack

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "css-loader": "^0.9.1",
     "d3-dsv": "^0.1.5",
     "eslint": "^1.10.3",
+    "eslint-loader": "^1.6.1",
     "eslint-plugin-react": "^3.16.1",
     "exports-loader": "^0.6.2",
     "expose-loader": "^0.7.0",

--- a/website/webpack.config.js
+++ b/website/webpack.config.js
@@ -32,6 +32,12 @@ module.exports = {
 		port: port
 	},
 	module: {
+		preLoaders: [
+		  {
+		    test: /\.jsx?$/,
+		    loaders: ['eslint'],
+		  }
+		],
 		loaders: [
 			// The next three are required for muts-needle-plot.
 			{ test: /d3-svg-legend/, loader: "imports?d3=d3" },


### PR DESCRIPTION
Background: We currently use es-lint to ensure code consistency, but it has to be run manually using `npm run lint` otherwise errors will not be seen until an attempted PR is rejected (es-lint is run by circle-ci).

This change would automatically run ES-Lint as part of `npm run` through webpack so errors would be brought up immediately.