### PR TITLE
Closes #327 -- ignore cases where order changes during diff process

### DIFF
--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -69,7 +69,7 @@ class transformer(object):
         listsAreConsistent = False
         if oldValues is None or newValues is None:
             return False
-        elif field == "Pathogenicity_all":
+        elif re.search(";", oldValues) and re.search(";", newValues):
             return equivalentSemicolonDelimitedValues(oldValues, newValues)
         elif re.search(",", oldValues) and re.search(",", newValues):
             oldTokens = oldValues.split(",")

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -69,8 +69,8 @@ class transformer(object):
         listsAreConsistent = False
         if oldValues is None or newValues is None:
             return False
-        elif re.search(";", oldValues) and re.search(";", newValues):
-            return equivalentSemicolonDelimitedValues(oldValues, newValues)
+        elif field == "Pathogenicity_all":
+            return equivalentPathogenicityAllValues(oldValues, newValues)
         elif re.search(",", oldValues) and re.search(",", newValues):
             oldTokens = oldValues.split(",")
             newTokens = newValues.split(",")
@@ -262,7 +262,13 @@ def appendVariantChangeTypesToOutput(variantChangeTypes, v2, output):
             writer.writerows(result)
 
 
-def equivalentSemicolonDelimitedValues(oldValues, newValues):
+def equivalentPathogenicityAllValues(oldValues, newValues):
+    '''
+    Pathogenicity_all is delimited by semicolons and commas, and may also have
+    reorders that affect the ability to simply compare by delimited values. As such,
+    direct character comparison is used between semicolon delimited sources (see test cases
+    for examples).
+    '''
     valuesAreEquivalent = False
     oldTokens = oldValues.split(";")
     newTokens = newValues.split(";")

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -61,7 +61,7 @@ class transformer(object):
                     newColumnsAdded.append(ncol)
         return (oldColumnsRemoved, newColumnsAdded, newToOldNameMapping)
 
-    def _consistentDelimitedLists(self, oldValues, newValues):
+    def _consistentDelimitedLists(self, oldValues, newValues, field):
         """Determine if the old and new values are comma-separated
         lists in which the same elements have been assembled in
         a differnt order
@@ -69,6 +69,8 @@ class transformer(object):
         listsAreConsistent = False
         if oldValues is None or newValues is None:
             return False
+        elif field == "Pathogenicity_all":
+            return _determineConsistentPathogenicityAll(self, oldValues, newValues)
         elif re.search(",", oldValues) and re.search(",", newValues):
             oldTokens = oldValues.split(",")
             newTokens = newValues.split(",")
@@ -80,6 +82,9 @@ class transformer(object):
                     numberSharedTokens == len(oldTokens):
                 listsAreConsistent = True
         return listsAreConsistent
+
+    def _determineConsistentPathogenicityAll(self, oldValues, newValues):
+        return sorted(oldValues) == sorted(newValues)
 
     def _normalize(self, value):
         """Make all values similar for improved comparison"""
@@ -113,7 +118,7 @@ class transformer(object):
             elif oldValue == "-" or oldValue in newValue:
                 variant = newRow["pyhgvs_Genomic_Coordinate_38"]
                 return "added data: %s | %s" % (oldValue, newValue)
-            elif self._consistentDelimitedLists(oldValue, newValue):
+            elif self._consistentDelimitedLists(oldValue, newValue, field):
                 return "unchanged"
             elif self._makeExpectedChanges.has_key(field):
                 updatedOldValue = self._normalize(self._makeExpectedChanges[field](oldValue))

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -70,7 +70,7 @@ class transformer(object):
         if oldValues is None or newValues is None:
             return False
         elif field == "Pathogenicity_all":
-            return _determineConsistentPathogenicityAll(self, oldValues, newValues)
+            return self._determineConsistentPathogenicityAll(oldValues, newValues)
         elif re.search(",", oldValues) and re.search(",", newValues):
             oldTokens = oldValues.split(",")
             newTokens = newValues.split(",")
@@ -84,7 +84,7 @@ class transformer(object):
         return listsAreConsistent
 
     def _determineConsistentPathogenicityAll(self, oldValues, newValues):
-        return sorted(oldValues) == sorted(newValues)
+        return sorted(oldValues.strip()) == sorted(newValues.strip())
 
     def _normalize(self, value):
         """Make all values similar for improved comparison"""

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -70,7 +70,7 @@ class transformer(object):
         if oldValues is None or newValues is None:
             return False
         elif field == "Pathogenicity_all":
-            return self._determineConsistentPathogenicityAll(oldValues, newValues)
+            return equivalentSemicolonDelimitedValues(oldValues, newValues)
         elif re.search(",", oldValues) and re.search(",", newValues):
             oldTokens = oldValues.split(",")
             newTokens = newValues.split(",")
@@ -82,9 +82,6 @@ class transformer(object):
                     numberSharedTokens == len(oldTokens):
                 listsAreConsistent = True
         return listsAreConsistent
-
-    def _determineConsistentPathogenicityAll(self, oldValues, newValues):
-        return sorted(oldValues.strip()) == sorted(newValues.strip())
 
     def _normalize(self, value):
         """Make all values similar for improved comparison"""
@@ -263,6 +260,22 @@ def appendVariantChangeTypesToOutput(variantChangeTypes, v2, output):
                 result.append(row)
 
             writer.writerows(result)
+
+
+def equivalentSemicolonDelimitedValues(oldValues, newValues):
+    valuesAreEquivalent = False
+    oldTokens = oldValues.split(";")
+    newTokens = newValues.split(";")
+    numberSharedTokens = 0
+    for token in oldTokens:
+        sortedOldToken = sorted(token)
+        for newToken in newTokens:
+            if sortedOldToken == sorted(newToken):
+                numberSharedTokens += 1
+    if numberSharedTokens == len(newTokens) and \
+            numberSharedTokens == len(oldTokens):
+        valuesAreEquivalent = True
+    return valuesAreEquivalent
 
 
 def generateReadme(args):

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -1,0 +1,30 @@
+import pytest
+import unittest
+from releaseDiff import equivalentSemicolonDelimitedValues
+
+
+class TestStringMethods(unittest.TestCase):
+
+    def test_reordered_pathogenicity_all_data(self):
+        prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
+        new = "Likely_benign,Uncertain_significance (ClinVar); Pending (BIC)"
+        self.assertTrue(equivalentSemicolonDelimitedValues(prev, new))
+
+    def test_swapped_pathogenicity_all_data(self):
+        prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
+        new = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
+        self.assertFalse(equivalentSemicolonDelimitedValues(prev, new))
+
+    def test_different_pathogenicity_all_data(self):
+        prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
+        new = "Likely_benign (ClinVar); Pending (BIC)"
+        self.assertFalse(equivalentSemicolonDelimitedValues(prev, new))
+
+    def test_same_pathogenicity_all_data_single_source(self):
+        prev = "Uncertain_significance,Likely_benign (ClinVar)"
+        new = "Likely_benign,Uncertain_significance (ClinVar)"
+        self.assertTrue(equivalentSemicolonDelimitedValues(prev, new))
+
+
+if __name__ == '__main__':
+    pass

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -1,6 +1,6 @@
 import pytest
 import unittest
-from releaseDiff import equivalentSemicolonDelimitedValues
+from releaseDiff import equivalentPathogenicityAllValues
 
 
 class TestStringMethods(unittest.TestCase):
@@ -8,22 +8,22 @@ class TestStringMethods(unittest.TestCase):
     def test_reordered_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Likely_benign,Uncertain_significance (ClinVar); Pending (BIC)"
-        self.assertTrue(equivalentSemicolonDelimitedValues(prev, new))
+        self.assertTrue(equivalentPathogenicityAllValues(prev, new))
 
     def test_swapped_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
-        self.assertFalse(equivalentSemicolonDelimitedValues(prev, new))
+        self.assertFalse(equivalentPathogenicityAllValues(prev, new))
 
     def test_different_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Likely_benign (ClinVar); Pending (BIC)"
-        self.assertFalse(equivalentSemicolonDelimitedValues(prev, new))
+        self.assertFalse(equivalentPathogenicityAllValues(prev, new))
 
     def test_same_pathogenicity_all_data_single_source(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar)"
         new = "Likely_benign,Uncertain_significance (ClinVar)"
-        self.assertTrue(equivalentSemicolonDelimitedValues(prev, new))
+        self.assertTrue(equivalentPathogenicityAllValues(prev, new))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
It turns out we only delimit using a semicolon on the `Pathogenicity_all` field, which means the comma delimited search we already have in place should catch other reorders.

Given that, I found that simply checking to make sure the exact same characters are in both the concatenated new and old values for `Pathogenicity_all` is a reliable check.