### PR TITLE
Closes #335: script to copy community data from production to beta

### DIFF
--- a/deployment/README.md
+++ b/deployment/README.md
@@ -96,3 +96,9 @@ To allow CCI to push code to azure, an authorized ssh key is added to the ssh co
 on the azure hosts. The ssh key can be managed in the CCI account settings.
 
 You may log in to circle-ci with your github credentials.
+
+# Community Data
+
+##### WARNING: This will delete and replace any relevant data in the beta database and `/var/www/backend/beta/django/uploads/` with data from production. Affected tables include all `auth` prefixed tables, all `users` prefixed tables, `django_admin_log`, and `django_content_type`.
+
+To copy community data from the production server and database to beta, run `sh deployment/copy-community-data.sh`.

--- a/deployment/copy-community-data.sh
+++ b/deployment/copy-community-data.sh
@@ -15,11 +15,11 @@ USER=brca
 # Copy community relevant DB data from production to beta
 ssh -l${USER} ${HOST} <<-ENDSSH
     set -o errexit
-    sudo chown -R www-data:www-data /var/www/backend/beta/django/uploads
     . /var/www/backend/beta/virtualenv/bin/activate
-    sudo rm -rf /var/www/backend/beta/django/uploads
-    cp -r /var/www/backend/production/django/uploads /var/www/backend/beta/django/uploads
     sudo -u postgres pg_dump -d production.pg -F c -t "^users*" -t django_admin_log -t django_content_type -t "^auth*" -c -f /tmp/users_seq.dump
     sudo -u postgres pg_restore /tmp/users_seq.dump -c -v -1 -d storage.pg
+    sudo chown -R www-data:www-data /var/www/backend/beta/django/uploads
+    sudo rm -rf /var/www/backend/beta/django/uploads
+    cp -r /var/www/backend/production/django/uploads /var/www/backend/beta/django/uploads
     sudo apache2ctl restart
 ENDSSH

--- a/deployment/copy-community-data.sh
+++ b/deployment/copy-community-data.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+# NOTE: This script copies community data from production to beta.
+
+######################################################################################
+#   WARNING: All `users` and `auth` prefixed tables, as well as `django_admin_log`   #
+#   `and django_content_type` tables will be dropped and all data will be replaced.  #
+######################################################################################
+
+HOST=${HOST:-brcaexchange.cloudapp.net}
+USER=brca
+
+# Copy community relevant DB data from production to beta
+ssh -l${USER} ${HOST} <<-ENDSSH
+    set -o errexit
+    sudo chown -R www-data:www-data /var/www/backend/beta/django/uploads
+    . /var/www/backend/beta/virtualenv/bin/activate
+    sudo rm -rf /var/www/backend/beta/django/uploads
+    cp -r /var/www/backend/production/django/uploads /var/www/backend/beta/django/uploads
+    sudo -u postgres pg_dump -d production.pg -F c -t "^users*" -t django_admin_log -t django_content_type -t "^auth*" -c -f /tmp/users_seq.dump
+    sudo -u postgres pg_restore /tmp/users_seq.dump -c -v -1 -d storage.pg
+    sudo apache2ctl restart
+ENDSSH


### PR DESCRIPTION
I opted to not automate this script during deploy since it deletes data from beta. My thinking is that a developer should have to consciously overwrite this data so nothing of importance is lost.

As always, open to any suggestions for improvement.