### PR TITLE
Remove last release

### DIFF
--- a/deployment/remove-release
+++ b/deployment/remove-release
@@ -1,0 +1,50 @@
+#!/bin/bash
+set -o nounset
+set -o errexit
+
+# This script expects two arguments:
+
+# 1. Environment (dev or beta)
+# 2. User (only necessary if dev)
+
+# Example:
+
+# Running `./deployment/remove-release dev zfischma`
+# would remove the most recent data release from zfischma's dev box.
+# Note that beta does not require a user argument as it defaults to user brca.
+
+# directory of this file
+DEPLOYMENT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+WEBSITE=${DEPLOYMENT}/../website
+
+# Expects environment (beta or production) as first argument.
+ENVIRONMENT=$1
+
+if [ "${ENVIRONMENT}" == "dev" && $# -lt 2 ] ;then
+	echo "ERROR: Please enter a user for the dev environment."
+    exit 1
+fi
+
+USER=${2:-brca}
+
+if [ "${ENVIRONMENT}" == "dev" ] ;then
+	HOST=${HOST:-brcaexchange-dev.cloudapp.net}
+	ssh -l${USER} ${HOST} <<-ENDSSH
+	    set -o errexit
+    	. /var/www/backend/beta/virtualenv/bin/activate
+	    python /home/${USER}/brca-exchange/website/django/manage.py remove_last_release
+	ENDSSH
+elif [ "${ENVIRONMENT}" == "beta" ] ;then
+	HOST=${HOST:-brcaexchange.cloudapp.net}
+	ssh -l${USER} ${HOST} <<-ENDSSH
+	    set -o errexit
+	    . /var/www/backend/${ENVIRONMENT}/virtualenv/bin/activate
+		python /var/www/backend/${ENVIRONMENT}/django/manage.py remove_last_release
+	ENDSSH
+else
+    echo "ERROR: Please only enter 'dev' or 'beta' as environment."
+    exit 1
+fi
+
+echo "Done!"
+

--- a/deployment/remove-release
+++ b/deployment/remove-release
@@ -17,7 +17,7 @@ set -o errexit
 DEPLOYMENT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 WEBSITE=${DEPLOYMENT}/../website
 
-# Expects environment (beta or production) as first argument.
+# Expects environment (dev or beta) as first argument.
 ENVIRONMENT=$1
 
 if [ "${ENVIRONMENT}" == "dev" && $# -lt 2 ] ;then
@@ -25,6 +25,7 @@ if [ "${ENVIRONMENT}" == "dev" && $# -lt 2 ] ;then
     exit 1
 fi
 
+# Expects user as second argument if environment is set to dev.
 USER=${2:-brca}
 
 if [ "${ENVIRONMENT}" == "dev" ] ;then

--- a/website/django/data/management/commands/remove_last_release.py
+++ b/website/django/data/management/commands/remove_last_release.py
@@ -1,0 +1,40 @@
+from django.core.management.base import BaseCommand, CommandError
+from django.db import connection
+from data.models import Variant, DataRelease
+
+
+class Command(BaseCommand):
+    help = 'Remove the most recent release from the database'
+
+    def update_autocomplete_words(self):
+        # Drop words table and recreate with latest data
+        with connection.cursor() as cursor:
+            cursor.execute("""
+                DROP TABLE IF EXISTS words;
+                CREATE TABLE words AS SELECT DISTINCT left(word, 300) as word, release_id FROM (
+                SELECT regexp_split_to_table(lower("Genomic_Coordinate_hg38"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("Genomic_Coordinate_hg37"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("Genomic_Coordinate_hg36"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("Clinical_significance_ENIGMA"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("Gene_Symbol"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("Reference_Sequence"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("HGVS_cDNA"), '[\s|:''"]')  as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("BIC_Nomenclature"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant UNION
+                SELECT regexp_split_to_table(lower("HGVS_Protein"), '[\s|''"]') as word, "Data_Release_id" as release_id from variant
+                )
+                AS combined_words;
+
+                CREATE INDEX words_idx ON words(word text_pattern_ops);
+            """)
+
+    def handle(self, *args, **options):
+        latest_release_id = DataRelease.objects.all().order_by("-id")[0]
+
+        Variant.objects.filter(Data_Release_id=latest_release_id).delete()
+        DataRelease.objects.filter(id=latest_release_id).delete()
+
+        self.update_autocomplete_words()
+
+        # update materialized view of current variants
+        with connection.cursor() as cursor:
+            cursor.execute("REFRESH MATERIALIZED VIEW currentvariant")

--- a/website/django/data/management/commands/remove_last_release.py
+++ b/website/django/data/management/commands/remove_last_release.py
@@ -47,3 +47,4 @@ class Command(BaseCommand):
         self.update_autocomplete_words()
 
         print "Updated autocomplete words."
+        print "Done!"


### PR DESCRIPTION
Problem: When testing new data releases, we often find problems that require rerunning the pipeline or adjusting the output from the pipeline. Sometimes, this requires removing an incorrect version of a release after it has been added to the database. Currently, removing a release is done manually by logging in to the desired server and deleting data from specific columns and updating materialized views and the automcomplete table.

Solution: This PR adds a script to remove the latest data release from a specified environment. It can be run with a single command on local, dev (user must be specified on dev), or beta.

