### PR TITLE
Fix release diff miss equal proteins

### DIFF
--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -159,7 +159,8 @@ class transformer(object):
 
         # Uncomment if using old data schema (e.g. pre pyhgvs_Genomic_Coordinate_38)
         columns_to_ignore = ["change_type", "Assertion_method_citation_ENIGMA", "Genomic_Coordinate_hg36",
-                             "Genomic_Coordinate_hg37", "Genomic_Coordinate_hg38", "HGVS_cDNA", "HGVS_Protein"]
+                             "Genomic_Coordinate_hg37", "Genomic_Coordinate_hg38", "HGVS_cDNA", "HGVS_Protein",
+                             "Hg37_Start", "Hg37_End", "Hg36_Start", "Hg36_End"]
 
         # Header to group all logs the same variant
         variant_intro = "\n\n %s \n Old Source: %s \n New Source: %s \n\n" % (newRow["pyhgvs_Genomic_Coordinate_38"],
@@ -328,7 +329,6 @@ def determineDiffForJSON(field, oldValue, newValue):
                 "Clinical_Significance_ClinVar",
                 "Allele_Origin_ClinVar",
                 "Synonyms",
-                "Genomic_Coordinate_hg38"
                ]
 
     if field in ADJUSTED_COLUMN_NAMES:
@@ -360,8 +360,8 @@ def determineDiffForJSON(field, oldValue, newValue):
 
     # If added and removed are the same, this should not need to run.
     if added == removed:
-        logging.error("Added: %s and Removed: %s properties are equal for Field: %s, "
-                      "there is a bug somewhere before this code.", added, removed, field)
+        logging.error("Added: %s and Removed: %s properties are equal for Field: %s (Adjusted Field: %s), "
+                      "there is a bug somewhere before this code.", added, removed, field, adjusted_field)
         return diff
 
     if not isEmpty(added):

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -5,7 +5,6 @@ import csv
 import re
 import json
 import logging
-import pdb
 
 
 added_data = None

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -5,7 +5,6 @@ import csv
 import re
 import json
 import logging
-import pdb
 
 
 added_data = None
@@ -108,8 +107,6 @@ class transformer(object):
         the field is added, has cosmetic changes, has major changes, or
         is unchanged.
         """
-        if field == "HGVS_Protein":
-            pdb.set_trace()
         global added_data
         variant = newRow["pyhgvs_Genomic_Coordinate_38"]
         newValue = self._normalize(newRow[field])
@@ -148,7 +145,8 @@ class transformer(object):
         global total_variants_with_changes
 
         # Uncomment if using old data schema (e.g. pre pyhgvs_Genomic_Coordinate_38)
-        columns_to_ignore = ["change_type", "Assertion_method_citation_ENIGMA"]
+        columns_to_ignore = ["change_type", "Assertion_method_citation_ENIGMA", "Genomic_Coordinate_hg36",
+                             "Genomic_Coordinate_hg37", "Genomic_Coordinate_hg38", "HGVS_cDNA", "HGVS_Protein"]
 
         # Header to group all logs the same variant
         variant_intro = "\n\n %s \n Old Source: %s \n New Source: %s \n\n" % (newRow["pyhgvs_Genomic_Coordinate_38"],

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -5,6 +5,7 @@ import csv
 import re
 import json
 import logging
+import pdb
 
 
 added_data = None
@@ -24,6 +25,19 @@ CHANGE_TYPES = {
 
 # Field used to denote pathogenic classification of a variant from all sources
 CLASSIFICATION_FIELD = "Pathogenicity_all"
+
+# The following columns are stored in the DB with the following name adjustments
+ADJUSTED_COLUMN_NAMES = {
+    'pyhgvs_Genomic_Coordinate_38': 'Genomic_Coordinate_hg38',
+    'pyhgvs_Genomic_Coordinate_37': 'Genomic_Coordinate_hg37',
+    'pyhgvs_Genomic_Coordinate_36': 'Genomic_Coordinate_hg36',
+    'pyhgvs_Hg37_Start': 'Hg37_Start',
+    'pyhgvs_Hg37_End': 'Hg37_End',
+    'pyhgvs_Hg36_Start': 'Hg36_Start',
+    'pyhgvs_Hg36_End': 'Hg36_End',
+    'pyhgvs_cDNA': 'HGVS_cDNA',
+    'pyhgvs_Protein': 'HGVS_Protein'
+}
 
 
 class transformer(object):
@@ -318,12 +332,18 @@ def determineDiffForJSON(field, oldValue, newValue):
                 "Genomic_Coordinate_hg38"
                ]
 
+    if field in ADJUSTED_COLUMN_NAMES:
+        adjusted_field = ADJUSTED_COLUMN_NAMES[field]
+    else:
+        adjusted_field = field
+
     diff = {
-            'field': field,
+            'field': adjusted_field,
             'field_type': None,
             'added': None,
             'removed': None
             }
+
     if field in listKeys:
         diff['field_type'] = 'list'
     else:

--- a/pipeline/utilities/releaseDiff.py
+++ b/pipeline/utilities/releaseDiff.py
@@ -5,6 +5,7 @@ import csv
 import re
 import json
 import logging
+import pdb
 
 
 added_data = None
@@ -107,6 +108,8 @@ class transformer(object):
         the field is added, has cosmetic changes, has major changes, or
         is unchanged.
         """
+        if field == "HGVS_Protein":
+            pdb.set_trace()
         global added_data
         variant = newRow["pyhgvs_Genomic_Coordinate_38"]
         newValue = self._normalize(newRow[field])
@@ -323,7 +326,6 @@ def determineDiffForJSON(field, oldValue, newValue):
             'added': None,
             'removed': None
             }
-
     if field in listKeys:
         diff['field_type'] = 'list'
     else:
@@ -338,6 +340,12 @@ def determineDiffForJSON(field, oldValue, newValue):
     elif diff['field_type'] == 'individual':
         added = newValue
         removed = oldValue
+
+    # If added and removed are the same, this should not need to run.
+    if added == removed:
+        logging.error("Added: %s and Removed: %s properties are equal for Field: %s, "
+                      "there is a bug somewhere before this code.", added, removed, field)
+        return diff
 
     if not isEmpty(added):
         diff['added'] = added

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -1,11 +1,59 @@
 import pytest
 import unittest
-from releaseDiff import (equivalentPathogenicityAllValues, checkPathogenicityAllDiffBySource,
-                         determineDiffForPathogenicityAll, determineDiffForJSON, transformer,
-                         v1ToV2)
+import tempfile
+import csv
+import releaseDiff
+from os import path
 
 
 class TestStringMethods(unittest.TestCase):
+
+    def setUp(self):
+        self.fieldnames = [
+                      'Pathogenicity_all',
+                      'Source',
+                      'HGVS_Protein',
+                      'Pathogenicity_expert',
+                      'Genomic_Coordinate_hg38',
+                      'pyhgvs_Genomic_Coordinate_38',
+                      'pyhgvs_Protein'
+                     ]
+        self.oldRow = {
+                  'Pathogenicity_all': '',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+        self.newRow = {
+                  'Pathogenicity_all': '',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+
+        self.test_dir = tempfile.mkdtemp()
+
+        self.added = csv.DictWriter(open(path.join(self.test_dir, 'removed.tsv'), 'w'), delimiter="\t", fieldnames=self.fieldnames)
+        self.added.writeheader()
+
+        self.removed = csv.DictWriter(open(path.join(self.test_dir, 'added.tsv'), 'w'), delimiter="\t", fieldnames=self.fieldnames)
+        self.removed.writeheader()
+
+        self.added_data = open(path.join(self.test_dir, 'added_data.tsv'), 'w')
+
+        self.diff = open(path.join(self.test_dir, 'diff.txt'), 'w')
+
+        self.total_variants_with_additions = 0
+
+        self.total_variants_with_changes = 0
+
+        self.diff_json = {}
 
     ###################################
     # Tests for determining change type
@@ -14,22 +62,22 @@ class TestStringMethods(unittest.TestCase):
     def test_reordered_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Likely_benign,Uncertain_significance (ClinVar); Pending (BIC)"
-        self.assertTrue(equivalentPathogenicityAllValues(prev, new))
+        self.assertTrue(releaseDiff.equivalentPathogenicityAllValues(prev, new))
 
     def test_swapped_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
-        self.assertFalse(equivalentPathogenicityAllValues(prev, new))
+        self.assertFalse(releaseDiff.equivalentPathogenicityAllValues(prev, new))
 
     def test_different_pathogenicity_all_data(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar); Pending (BIC)"
         new = "Likely_benign (ClinVar); Pending (BIC)"
-        self.assertFalse(equivalentPathogenicityAllValues(prev, new))
+        self.assertFalse(releaseDiff.equivalentPathogenicityAllValues(prev, new))
 
     def test_same_pathogenicity_all_data_single_source(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar)"
         new = "Likely_benign,Uncertain_significance (ClinVar)"
-        self.assertTrue(equivalentPathogenicityAllValues(prev, new))
+        self.assertTrue(releaseDiff.equivalentPathogenicityAllValues(prev, new))
 
     ###################################
     # Tests for determining diff json
@@ -40,7 +88,7 @@ class TestStringMethods(unittest.TestCase):
     def test_pathogenicity_all_diff_by_source_same_values_different_order(self):
         prev = "Uncertain_significance,Likely_benign (ClinVar)"
         new = "Likely_benign,Uncertain_significance (ClinVar)"
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("ClinVar", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("ClinVar", prev, new)
         self.assertEqual(classificationAdded, '')
         self.assertEqual(classificationRemoved, '')
 
@@ -49,12 +97,12 @@ class TestStringMethods(unittest.TestCase):
         new = ["Likely_benign,Pathogenic (ClinVar)", "Pending (BIC)"]
 
         # Test ClinVar change
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("ClinVar", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("ClinVar", prev, new)
         self.assertEqual(classificationAdded, 'Pathogenic (ClinVar)')
         self.assertEqual(classificationRemoved, 'Uncertain_significance (ClinVar)')
 
         # Test BIC no change
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("BIC", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("BIC", prev, new)
         self.assertEqual(classificationAdded, '')
         self.assertEqual(classificationRemoved, '')
 
@@ -63,12 +111,12 @@ class TestStringMethods(unittest.TestCase):
         new = ["Uncertain_significance,Likely_benign,Pending (ClinVar)", "Pending (BIC)"]
 
         # Test ClinVar change
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("ClinVar", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("ClinVar", prev, new)
         self.assertEqual(classificationAdded, 'Uncertain_significance,Likely_benign (ClinVar)')
         self.assertEqual(classificationRemoved, '')
 
         # Test BIC
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("BIC", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("BIC", prev, new)
         self.assertEqual(classificationAdded, 'Pending (BIC)')
         self.assertEqual(classificationRemoved, 'Uncertain_significance,Likely_benign (BIC)')
 
@@ -77,19 +125,19 @@ class TestStringMethods(unittest.TestCase):
         new = ["Uncertain_significance,Likely_benign,Pending (BIC)"]
 
         # Test ClinVar change
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("ClinVar", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("ClinVar", prev, new)
         self.assertEqual(classificationAdded, '')
         self.assertEqual(classificationRemoved, 'Pending (ClinVar)')
 
         # Test BIC change
-        (classificationAdded, classificationRemoved) = checkPathogenicityAllDiffBySource("BIC", prev, new)
+        (classificationAdded, classificationRemoved) = releaseDiff.checkPathogenicityAllDiffBySource("BIC", prev, new)
         self.assertEqual(classificationAdded, 'Uncertain_significance,Likely_benign,Pending (BIC)')
         self.assertEqual(classificationRemoved, '')
 
     def test_pathogenicity_all_diff_change(self):
         prev = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
         new = "Uncertain_significance,Likely_benign,Pending (ClinVar); Pending (BIC)"
-        (added, removed) = determineDiffForPathogenicityAll(prev, new)
+        (added, removed) = releaseDiff.determineDiffForPathogenicityAll(prev, new)
         self.assertIn('Pending (BIC)', added)
         self.assertIn('Uncertain_significance,Likely_benign (ClinVar)', added)
         self.assertIn('Uncertain_significance,Likely_benign (BIC)', removed)
@@ -98,7 +146,7 @@ class TestStringMethods(unittest.TestCase):
     def test_pathogenicity_all_diff_no_change(self):
         prev = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
         new = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
-        (added, removed) = determineDiffForPathogenicityAll(prev, new)
+        (added, removed) = releaseDiff.determineDiffForPathogenicityAll(prev, new)
         self.assertIsNone(added)
         self.assertIsNone(removed)
 
@@ -106,7 +154,7 @@ class TestStringMethods(unittest.TestCase):
         field = "Pathogenicity_all"
         prev = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
         new = "Uncertain_significance,Likely_benign (BIC); Pending (ClinVar)"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'Pathogenicity_all')
         self.assertEqual(diff['field_type'], 'list')
         self.assertIsNone(diff['added'])
@@ -118,7 +166,7 @@ class TestStringMethods(unittest.TestCase):
         field = "Source"
         prev = "BIC,ClinVar,ENIGMA"
         new = "ClinVar"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'Source')
         self.assertEqual(diff['field_type'], 'list')
         self.assertIsNone(diff['added'])
@@ -128,7 +176,7 @@ class TestStringMethods(unittest.TestCase):
         field = "Source_URL"
         prev = "http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000075545, http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000187590, http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000144137"
         new = "http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000187590, http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000075545, http://www.ncbi.nlm.nih.gov/clinvar/?term=SCV000144137"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'Source_URL')
         self.assertEqual(diff['field_type'], 'list')
         self.assertIsNone(diff['added'])
@@ -139,7 +187,7 @@ class TestStringMethods(unittest.TestCase):
         prev = "-"
         new = ("c/o_University_of_Cambridge,The_Consortium_of_Investigators_of_Modifiers_of_BRCA1/2_(CIMBA),"
                "Ambry_Genetics,Breast_Cancer_Information_Core_(BIC)_(BRCA2),Invitae")
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'Submitter_ClinVar')
         self.assertEqual(diff['field_type'], 'list')
         self.assertIn('c/o_University_of_Cambridge', diff['added'])
@@ -153,7 +201,7 @@ class TestStringMethods(unittest.TestCase):
         field = "HGVS_Protein"
         prev = "NM_000059:p.His1085Arg"
         new = "p.(His1085Arg)"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'HGVS_Protein')
         self.assertEqual(diff['field_type'], 'individual')
         self.assertEqual(diff['added'], 'p.(His1085Arg)')
@@ -163,7 +211,7 @@ class TestStringMethods(unittest.TestCase):
         field = "HGVS_Protein"
         prev = "NM_000059:p.His1085Arg"
         new = "-"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'HGVS_Protein')
         self.assertEqual(diff['field_type'], 'individual')
         self.assertEqual(diff['added'], '-')
@@ -173,7 +221,7 @@ class TestStringMethods(unittest.TestCase):
         field = "HGVS_Protein"
         prev = "-"
         new = "NM_000059:p.His1085Arg"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'HGVS_Protein')
         self.assertEqual(diff['field_type'], 'individual')
         self.assertEqual(diff['added'], 'NM_000059:p.His1085Arg')
@@ -183,188 +231,24 @@ class TestStringMethods(unittest.TestCase):
         field = "HGVS_Protein"
         prev = "NM_000059:p.His1085Arg"
         new = "NM_000059:p.His1085Arg"
-        diff = determineDiffForJSON(field, prev, new)
+        diff = releaseDiff.determineDiffForJSON(field, prev, new)
         self.assertEqual(diff['field'], 'HGVS_Protein')
         self.assertEqual(diff['field_type'], 'individual')
         self.assertIsNone(diff['added'])
         self.assertIsNone(diff['removed'])
 
+    # Test full releaseDiff output by using rows of data from release
+
     def test_compare_row_equal_rows(self):
-        fieldnames = [
-                      'Pathogenicity_all',
-                      'pyhgvs_cDNA',
-                      'Source',
-                      'HGVS_Protein',
-                      'Polyphen_Score',
-                      'pyhgvs_Hg37_Start',
-                      'Hg38_End',
-                      'HGVS_cDNA',
-                      'Hg37_End',
-                      'Hg38_Start',
-                      'Pathogenicity_expert',
-                      'pyhgvs_Hg36_End',
-                      'Hg36_End',
-                      'pyhgvs_Hg37_End',
-                      'Genomic_Coordinate_hg37',
-                      'Genomic_Coordinate_hg36',
-                      'pyhgvs_Genomic_Coordinate_37',
-                      'pyhgvs_Genomic_Coordinate_36',
-                      'Genomic_Coordinate_hg38',
-                      'pyhgvs_Hg36_Start',
-                      'pyhgvs_Genomic_Coordinate_38',
-                      'Protein_Change',
-                      'HGVS_RNA',
-                      'Hg37_Start',
-                      'Hg36_Start',
-                      'pyhgvs_Protein'
-                     ]
-        oldRow = {
-                  'Pathogenicity_all': '',
-                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
-                  'Source': 'LOVD,1000_Genomes',
-                  'HGVS_Protein': '-',
-                  'Polyphen_Score': '-',
-                  'pyhgvs_Hg37_Start': '41201084',
-                  'Hg38_End': '43049067',
-                  'HGVS_cDNA': 'c.5406+54G>A',
-                  'Hg37_End': '-',
-                  'Hg38_Start': '43049067',
-                  'Pathogenicity_expert': 'Not Yet Reviewed',
-                  'pyhgvs_Hg36_End': '38454610',
-                  'Hg36_End': '-',
-                  'pyhgvs_Hg37_End': '41201084',
-                  'Genomic_Coordinate_hg37': '-',
-                  'Genomic_Coordinate_hg36': '-',
-                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
-                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
-                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Hg36_Start': '38454610',
-                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
-                  'Protein_Change': '-',
-                  'HGVS_RNA': '-',
-                  'Hg37_Start': '-',
-                  'Hg36_Start': '-',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
-                 }
-        newRow = {
-                  'Pathogenicity_all': '',
-                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
-                  'Source': 'LOVD,1000_Genomes',
-                  'HGVS_Protein': '-',
-                  'Polyphen_Score': '-',
-                  'pyhgvs_Hg37_Start': '41201084',
-                  'Hg38_End': '43049067',
-                  'HGVS_cDNA': 'c.5406+54G>A',
-                  'Hg37_End': '-',
-                  'Hg38_Start': '43049067',
-                  'Pathogenicity_expert': 'Not Yet Reviewed',
-                  'pyhgvs_Hg36_End': '38454610',
-                  'Hg36_End': '-',
-                  'pyhgvs_Hg37_End': '41201084',
-                  'Genomic_Coordinate_hg37': '-',
-                  'Genomic_Coordinate_hg36': '-',
-                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
-                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
-                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Hg36_Start': '38454610',
-                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
-                  'Protein_Change': '-',
-                  'HGVS_RNA': '-',
-                  'Hg37_Start': '-',
-                  'Hg36_Start': '-',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
-                 }
-        v1v2 = v1ToV2(fieldnames, fieldnames)
-        change_type = v1v2.compareRow(oldRow, newRow)
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
         self.assertIsNone(change_type)
 
     def test_compare_row_added_data(self):
-        fieldnames = [
-                      'Pathogenicity_all',
-                      'pyhgvs_cDNA',
-                      'Source',
-                      'HGVS_Protein',
-                      'Polyphen_Score',
-                      'pyhgvs_Hg37_Start',
-                      'Hg38_End',
-                      'HGVS_cDNA',
-                      'Hg37_End',
-                      'Hg38_Start',
-                      'Pathogenicity_expert',
-                      'pyhgvs_Hg36_End',
-                      'Hg36_End',
-                      'pyhgvs_Hg37_End',
-                      'Genomic_Coordinate_hg37',
-                      'Genomic_Coordinate_hg36',
-                      'pyhgvs_Genomic_Coordinate_37',
-                      'pyhgvs_Genomic_Coordinate_36',
-                      'Genomic_Coordinate_hg38',
-                      'pyhgvs_Hg36_Start',
-                      'pyhgvs_Genomic_Coordinate_38',
-                      'Protein_Change',
-                      'HGVS_RNA',
-                      'Hg37_Start',
-                      'Hg36_Start',
-                      'pyhgvs_Protein'
-                     ]
-        oldRow = {
-                  'Pathogenicity_all': '',
-                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
-                  'Source': 'LOVD,1000_Genomes',
-                  'HGVS_Protein': '-',
-                  'Polyphen_Score': '-',
-                  'pyhgvs_Hg37_Start': '41201084',
-                  'Hg38_End': '43049067',
-                  'HGVS_cDNA': 'c.5406+54G>A',
-                  'Hg37_End': '-',
-                  'Hg38_Start': '43049067',
-                  'Pathogenicity_expert': 'Not Yet Reviewed',
-                  'pyhgvs_Hg36_End': '38454610',
-                  'Hg36_End': '-',
-                  'pyhgvs_Hg37_End': '41201084',
-                  'Genomic_Coordinate_hg37': '-',
-                  'Genomic_Coordinate_hg36': '-',
-                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
-                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
-                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Hg36_Start': '38454610',
-                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
-                  'Protein_Change': '-',
-                  'HGVS_RNA': '-',
-                  'Hg37_Start': '-',
-                  'Hg36_Start': '-',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
-                 }
-        newRow = {
-                  'Pathogenicity_all': 'Benign (ClinVar)',
-                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
-                  'Source': 'LOVD,1000_Genomes',
-                  'HGVS_Protein': '-',
-                  'Polyphen_Score': '-',
-                  'pyhgvs_Hg37_Start': '41201084',
-                  'Hg38_End': '43049067',
-                  'HGVS_cDNA': 'c.5406+54G>A',
-                  'Hg37_End': '-',
-                  'Hg38_Start': '43049067',
-                  'Pathogenicity_expert': 'Not Yet Reviewed',
-                  'pyhgvs_Hg36_End': '38454610',
-                  'Hg36_End': '-',
-                  'pyhgvs_Hg37_End': '41201084',
-                  'Genomic_Coordinate_hg37': '-',
-                  'Genomic_Coordinate_hg36': '-',
-                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
-                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
-                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
-                  'pyhgvs_Hg36_Start': '38454610',
-                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
-                  'Protein_Change': '-',
-                  'HGVS_RNA': '-',
-                  'Hg37_Start': '-',
-                  'Hg36_Start': '-',
-                  'pyhgvs_Protein': 'NP_009225.1:p.?'
-                 }
-        v1v2 = v1ToV2(fieldnames, fieldnames)
-        change_type = v1v2.compareRow(oldRow, newRow)
+        releaseDiff.added_data = self.added_data
+        self.newRow['Source'] += ",ENIGMA"
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
         self.assertEqual(change_type, "added_information")
 
 

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -178,6 +178,16 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(diff['added'], 'NM_000059:p.His1085Arg')
         self.assertEqual(diff['removed'], '-')
 
+    def test_diff_json_handles_hgvs_protein_non_changes_correctly(self):
+        field = "HGVS_Protein"
+        prev = "NM_000059:p.His1085Arg"
+        new = "NM_000059:p.His1085Arg"
+        diff = determineDiffForJSON(field, prev, new)
+        self.assertEqual(diff['field'], 'HGVS_Protein')
+        self.assertEqual(diff['field_type'], 'individual')
+        self.assertIsNone(diff['added'])
+        self.assertIsNone(diff['removed'])
+
 
 if __name__ == '__main__':
     pass

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -1,7 +1,8 @@
 import pytest
 import unittest
 from releaseDiff import (equivalentPathogenicityAllValues, checkPathogenicityAllDiffBySource,
-                         determineDiffForPathogenicityAll, determineDiffForJSON)
+                         determineDiffForPathogenicityAll, determineDiffForJSON, transformer,
+                         v1ToV2)
 
 
 class TestStringMethods(unittest.TestCase):
@@ -187,6 +188,184 @@ class TestStringMethods(unittest.TestCase):
         self.assertEqual(diff['field_type'], 'individual')
         self.assertIsNone(diff['added'])
         self.assertIsNone(diff['removed'])
+
+    def test_compare_row_equal_rows(self):
+        fieldnames = [
+                      'Pathogenicity_all',
+                      'pyhgvs_cDNA',
+                      'Source',
+                      'HGVS_Protein',
+                      'Polyphen_Score',
+                      'pyhgvs_Hg37_Start',
+                      'Hg38_End',
+                      'HGVS_cDNA',
+                      'Hg37_End',
+                      'Hg38_Start',
+                      'Pathogenicity_expert',
+                      'pyhgvs_Hg36_End',
+                      'Hg36_End',
+                      'pyhgvs_Hg37_End',
+                      'Genomic_Coordinate_hg37',
+                      'Genomic_Coordinate_hg36',
+                      'pyhgvs_Genomic_Coordinate_37',
+                      'pyhgvs_Genomic_Coordinate_36',
+                      'Genomic_Coordinate_hg38',
+                      'pyhgvs_Hg36_Start',
+                      'pyhgvs_Genomic_Coordinate_38',
+                      'Protein_Change',
+                      'HGVS_RNA',
+                      'Hg37_Start',
+                      'Hg36_Start',
+                      'pyhgvs_Protein'
+                     ]
+        oldRow = {
+                  'Pathogenicity_all': '',
+                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Polyphen_Score': '-',
+                  'pyhgvs_Hg37_Start': '41201084',
+                  'Hg38_End': '43049067',
+                  'HGVS_cDNA': 'c.5406+54G>A',
+                  'Hg37_End': '-',
+                  'Hg38_Start': '43049067',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'pyhgvs_Hg36_End': '38454610',
+                  'Hg36_End': '-',
+                  'pyhgvs_Hg37_End': '41201084',
+                  'Genomic_Coordinate_hg37': '-',
+                  'Genomic_Coordinate_hg36': '-',
+                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
+                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Hg36_Start': '38454610',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'Protein_Change': '-',
+                  'HGVS_RNA': '-',
+                  'Hg37_Start': '-',
+                  'Hg36_Start': '-',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+        newRow = {
+                  'Pathogenicity_all': '',
+                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Polyphen_Score': '-',
+                  'pyhgvs_Hg37_Start': '41201084',
+                  'Hg38_End': '43049067',
+                  'HGVS_cDNA': 'c.5406+54G>A',
+                  'Hg37_End': '-',
+                  'Hg38_Start': '43049067',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'pyhgvs_Hg36_End': '38454610',
+                  'Hg36_End': '-',
+                  'pyhgvs_Hg37_End': '41201084',
+                  'Genomic_Coordinate_hg37': '-',
+                  'Genomic_Coordinate_hg36': '-',
+                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
+                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Hg36_Start': '38454610',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'Protein_Change': '-',
+                  'HGVS_RNA': '-',
+                  'Hg37_Start': '-',
+                  'Hg36_Start': '-',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+        v1v2 = v1ToV2(fieldnames, fieldnames)
+        change_type = v1v2.compareRow(oldRow, newRow)
+        self.assertIsNone(change_type)
+
+    def test_compare_row_added_data(self):
+        fieldnames = [
+                      'Pathogenicity_all',
+                      'pyhgvs_cDNA',
+                      'Source',
+                      'HGVS_Protein',
+                      'Polyphen_Score',
+                      'pyhgvs_Hg37_Start',
+                      'Hg38_End',
+                      'HGVS_cDNA',
+                      'Hg37_End',
+                      'Hg38_Start',
+                      'Pathogenicity_expert',
+                      'pyhgvs_Hg36_End',
+                      'Hg36_End',
+                      'pyhgvs_Hg37_End',
+                      'Genomic_Coordinate_hg37',
+                      'Genomic_Coordinate_hg36',
+                      'pyhgvs_Genomic_Coordinate_37',
+                      'pyhgvs_Genomic_Coordinate_36',
+                      'Genomic_Coordinate_hg38',
+                      'pyhgvs_Hg36_Start',
+                      'pyhgvs_Genomic_Coordinate_38',
+                      'Protein_Change',
+                      'HGVS_RNA',
+                      'Hg37_Start',
+                      'Hg36_Start',
+                      'pyhgvs_Protein'
+                     ]
+        oldRow = {
+                  'Pathogenicity_all': '',
+                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Polyphen_Score': '-',
+                  'pyhgvs_Hg37_Start': '41201084',
+                  'Hg38_End': '43049067',
+                  'HGVS_cDNA': 'c.5406+54G>A',
+                  'Hg37_End': '-',
+                  'Hg38_Start': '43049067',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'pyhgvs_Hg36_End': '38454610',
+                  'Hg36_End': '-',
+                  'pyhgvs_Hg37_End': '41201084',
+                  'Genomic_Coordinate_hg37': '-',
+                  'Genomic_Coordinate_hg36': '-',
+                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
+                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Hg36_Start': '38454610',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'Protein_Change': '-',
+                  'HGVS_RNA': '-',
+                  'Hg37_Start': '-',
+                  'Hg36_Start': '-',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+        newRow = {
+                  'Pathogenicity_all': 'Benign (ClinVar)',
+                  'pyhgvs_cDNA': 'NM_007294.3:c.5406+54G>A',
+                  'Source': 'LOVD,1000_Genomes',
+                  'HGVS_Protein': '-',
+                  'Polyphen_Score': '-',
+                  'pyhgvs_Hg37_Start': '41201084',
+                  'Hg38_End': '43049067',
+                  'HGVS_cDNA': 'c.5406+54G>A',
+                  'Hg37_End': '-',
+                  'Hg38_Start': '43049067',
+                  'Pathogenicity_expert': 'Not Yet Reviewed',
+                  'pyhgvs_Hg36_End': '38454610',
+                  'Hg36_End': '-',
+                  'pyhgvs_Hg37_End': '41201084',
+                  'Genomic_Coordinate_hg37': '-',
+                  'Genomic_Coordinate_hg36': '-',
+                  'pyhgvs_Genomic_Coordinate_37': 'chr17:g.41201084:C>T',
+                  'pyhgvs_Genomic_Coordinate_36': 'chr17:g.38454610:C>T',
+                  'Genomic_Coordinate_hg38': 'chr17:g.43049067:C>T',
+                  'pyhgvs_Hg36_Start': '38454610',
+                  'pyhgvs_Genomic_Coordinate_38': 'chr17:g.43049067:C>T',
+                  'Protein_Change': '-',
+                  'HGVS_RNA': '-',
+                  'Hg37_Start': '-',
+                  'Hg36_Start': '-',
+                  'pyhgvs_Protein': 'NP_009225.1:p.?'
+                 }
+        v1v2 = v1ToV2(fieldnames, fieldnames)
+        change_type = v1v2.compareRow(oldRow, newRow)
+        self.assertEqual(change_type, "added_information")
 
 
 if __name__ == '__main__':

--- a/pipeline/utilities/test_releaseDiff.py
+++ b/pipeline/utilities/test_releaseDiff.py
@@ -251,6 +251,39 @@ class TestStringMethods(unittest.TestCase):
         change_type = v1v2.compareRow(self.oldRow, self.newRow)
         self.assertEqual(change_type, "added_information")
 
+    def test_ignores_unused_column_changes_in_compare_row(self):
+        releaseDiff.added_data = self.added_data
+        self.oldRow['pyhgvs_Protein'] = "NP_009225.1:p.?"
+        self.newRow['HGVS_Protein'] = "NM_000059:p.His1085Arg"
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        self.assertIsNone(change_type)
+
+    def test_catches_new_column_changes_in_compare_row(self):
+        releaseDiff.added_data = self.added_data
+        releaseDiff.diff = self.diff
+        releaseDiff.diff_json = self.diff_json
+        variant = 'chr17:g.43049067:C>T'
+        self.oldRow['pyhgvs_Protein'] = "NP_009225.1:p.?"
+        self.newRow['pyhgvs_Protein'] = "NM_000059:p.His1085Arg"
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        diff = releaseDiff.diff_json[variant]
+        self.assertEqual(change_type, "changed_information")
+        self.assertIs(diff[0]['removed'], 'NP_009225.1:p.?')
+        self.assertIs(diff[0]['added'], 'NM_000059:p.His1085Arg')
+
+    def test_builds_diff_with_adjusted_column_names_to_match_db(self):
+        releaseDiff.added_data = self.added_data
+        releaseDiff.diff = self.diff
+        releaseDiff.diff_json = self.diff_json
+        variant = 'chr17:g.43049067:C>T'
+        self.oldRow['pyhgvs_Protein'] = "NP_009225.1:p.?"
+        self.newRow['pyhgvs_Protein'] = "NM_000059:p.His1085Arg"
+        v1v2 = releaseDiff.v1ToV2(self.fieldnames, self.fieldnames)
+        change_type = v1v2.compareRow(self.oldRow, self.newRow)
+        diff = releaseDiff.diff_json[variant]
+        self.assertIs(diff[0]['field'], 'HGVS_Protein')
 
 if __name__ == '__main__':
     pass


### PR DESCRIPTION
This PR addresses false diffs generated by diffing deprecated fields from built.tsv. For context:

zfisch [6:34 PM] 
^ we were previously including changes to the non-pyhgvs columns in our diff calculations. this change ensures our diff.json files do not reflect those false diffs -- though it does mean some of our change_types for previous releases are incorrect

zfisch [6:41 PM] 
e.g. variant `chr17:g.43091495:C>T` is currently considered changed in release 3 because it thinks the HGVS_Protein value changed from `NM_007294:p.Val1809Phe` to `p.(Val1809Phe)`. In reality, this is the deprecated HGVS_Protein value from built.tsv that changed. The more significant value, `pyhgvs_Protein`, is the same for all versions of the variant -- `NP_009225.1:p.(Val1809Phe)`. This is also the only value mentioned that gets stored in the db (confusingly, it's stored as `HGVS_Protein` even though it comes from the `pyhgvs_Protein` column). (edited)
