### PR TITLE
Fix typo in brcaexchange URL

### DIFF
--- a/website/django/data/static/python_notebook/brca-exchange.ipynb
+++ b/website/django/data/static/python_notebook/brca-exchange.ipynb
@@ -17,7 +17,7 @@
    "outputs": [],
    "source": [
     "from ga4gh.client import client\n",
-    "c = client.HttpClient(\"http://brca-exchange.org/backend/data/ga4gh/v0.6.0a7/\")"
+    "c = client.HttpClient(\"http://brcaexchange.org/backend/data/ga4gh/v0.6.0a7/\")"
    ]
   },
   {
@@ -414,7 +414,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.11"
+   "version": "2.7.12+"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
The python notebook was pointing to an incorrect URL. Close #427 

Thanks @Welliton309!